### PR TITLE
fix: added in remote fetching for sfoundryup+removed unnecessary docs

### DIFF
--- a/sfoundryup/README.md
+++ b/sfoundryup/README.md
@@ -14,32 +14,3 @@ To install the **nightly** version of Seismic Foundry tools:
 ```bash
 sfoundryup
 ```
-### Install a specific **version** (in this case the nightly version):
-```bash
-sfoundryup --version nightly
-```
-### Install a specific **branch** (in this case the seismic branch):
-```bash
-sfoundryup --branch seismic
-```
-### Install a **fork's main branch** (in this case YourUser/seismic-foundry's main branch):
-```bash
-sfoundryup --repo YourUser/seismic-foundry
-```
-### Install a **specific branch in a fork** (in this case the custom-branch branch's latest commit in YourUser/seismic-foundry):
-```bash
-sfoundryup --repo YourUser/seismic-foundry --branch custom-branch
-```
-### Install a **specific Pull Request**:
-```bash
-sfoundryup --pr 123
-```
-### Install from a **specific commit**:
-```bash
-sfoundryup -C abcdef1234567890
-```
-### Install from a **local directory or repository** (e.g., one located at ~/git/seismic-foundry, assuming you're in the home directory):
-```bash
-sfoundryup --path ./git/seismic-foundry
-```
-**Tip**: All flags have a single-character shorthand equivalent! You can use -v instead of --version, etc.

--- a/sfoundryup/sfoundryup
+++ b/sfoundryup/sfoundryup
@@ -140,8 +140,8 @@ install_from_remote_repo() {
 
   # Fetch and checkout the branch
   cd "$REPO_PATH"
-  ensure git fetch origin "$SEISMICUP_BRANCH"
-  ensure git checkout "$SEISMICUP_BRANCH"
+  ensure git fetch origin "${SEISMICUP_BRANCH}:remotes/origin/${SEISMICUP_BRANCH}"
+  ensure git checkout "origin/${SEISMICUP_BRANCH}"
 
   # Build the binaries
   ensure cargo build --bins "${CARGO_BUILD_ARGS[@]}"


### PR DESCRIPTION
I realized that that the repo was not getting updated ideally and was only checking out to the `seismic` branch without pulling in latest remote changes.
This PR introduces the following:
1. Fetches the latest for remote `origin/seismic` (`seismic:remotes/origin/seismic`)
2. Checks out the repo to `origin/seismic`, so that any local changes aren't affected/don't have to be stashed or overriden
3. removes some (currently) unnecessary docs from `sfoundryup` installation documentation