### PR TITLE
Adding `sanvil` ASCII art + colors + changing link

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -204,7 +204,11 @@ impl NodeConfig {
         let mut s: String = String::new();
         let _ = write!(s, "\n{}", BANNER.rgb(172, 103, 42));
         let _ = write!(s, "\n    {VERSION_MESSAGE}");
-        let _ = write!(s, "\n    {}", "https://github.com/SeismicSystems/seismic-foundry".rgb(172, 103, 42));
+        let _ = write!(
+            s,
+            "\n    {}",
+            "https://github.com/SeismicSystems/seismic-foundry".rgb(172, 103, 42)
+        );
 
         let _ = write!(
             s,


### PR DESCRIPTION
This PR introduces the following:
1. Custom `sanvil` GUI ASCII art (as seen [here](https://github.com/SeismicSystems/seismic-foundry/blob/883f7cb252ddefe42c04d95efabd0739e1fe25c7/crates/anvil/src/config.rs#L84))
2. A custom color (172R, 103G, 42B) for the art and corresponding headings
3. Link change from the original foundry repo to the `seismic-foundry` repo.