### PR TITLE
Removing `SEISMIC_PAT` from `install` and `sfoundryup` scripts

### DIFF
--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sanvil"
+name = "anvil"
 description = "Local ethereum node"
 
 version.workspace = true

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "anvil"
+name = "sanvil"
 description = "Local ethereum node"
 
 version.workspace = true

--- a/sfoundryup/README.md
+++ b/sfoundryup/README.md
@@ -1,7 +1,7 @@
 # `sfoundryup`
-Install, update, or revert to a specific branch, fork, or version of Seismic Foundry tools with ease.
+Install, and update the Seismic Foundry suite of developer tools with ease.
 ### Installing
-Run the following command to install sfoundryup:
+Run the following command to install `sfoundryup`:
 ```bash
 curl -L -H "Accept: application/vnd.github.v3.raw" \
      "https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/sfoundryup/install" | bash

--- a/sfoundryup/README.md
+++ b/sfoundryup/README.md
@@ -1,5 +1,5 @@
 # `sfoundryup`
-Install, and update the Seismic Foundry suite of developer tools with ease.
+Install and update the Seismic Foundry suite of developer tools with ease.
 ### Installing
 Run the following command to install `sfoundryup`:
 ```bash

--- a/sfoundryup/README.md
+++ b/sfoundryup/README.md
@@ -2,59 +2,38 @@
 Install, update, or revert to a specific branch, fork, or version of Seismic Foundry tools with ease.
 ## For developers building on top of Seismic
 ### Installing
-Before installing, ensure you have a **GitHub Personal Access Token (PAT)** with repository access. Export the token as an environment variable:
+Run the following command to install sfoundryup:
 ```bash
-export SEISMIC_PAT=your_personal_access_token
+curl -L -H "Accept: application/vnd.github.v3.raw" \
+     "https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/sfoundryup/install" | bash
 ```
-Then, run the following command to install sfoundryup:
+Now, either open a new terminal or reload your shell configuration to start using sfoundryup:
+
+For `bash` users:
 ```bash
-curl -L -H "Authorization: token $SEISMIC_PAT" \
-     -H "Accept: application/vnd.github.v3.raw" \
-     "https://api.github.com/repos/SeismicSystems/seismic-foundry/contents/sfoundryup/install?ref=seismic" | bash
+source ~/.bashrc
 ```
+
+For `zsh` users:
+```bash
+source ~/.zshrc
+```
+
+For `fish` users:
+```bash
+source ~/.config/fish/config.fish
+```
+
+For `ash` users:
+```bash
+source ~/.profile
+```
+
 ## Usage
-### Install Seismic Foundry as a developer building on top of Seismic:
+### Install Seismic Foundry:
 ```bash
 sfoundryup
 ```
 
-## For Seismic core team members
-Create the `~/.seismic/bin` directory if not already created
-```bash
-mkdir -p ~/.seismic/bin
 ```
-Add `~/.seismic/bin` to your shell (`~/.bashrc`, `~/.zshrc`, etc.)
-```bash
-echo 'export PATH="$PATH:$HOME/.seismic/bin"' >> ~/.bashrc ## Replace this with your shell configuration file
-```
-Clone the Seismic Foundry Repository if not already cloned to your local machine
-```bash
-git clone git@github.com:SeismicSystems/seismic-foundry.git
-```
-Navigate to the Repository
-```bash
-cd seismic-foundry
-```
-Pull the Latest Changes on the `seismic` Branch:
-```bash
-  git checkout seismic
-  git pull origin seismic
-```
-Copy `sfoundryup` to `~/.seismic/bin`:
-```bash
-   cp sfoundryup/sfoundryup ~/.seismic/bin/
-```
-Make the Script Executable:
-```bash
-   chmod +x ~/.seismic/bin/sfoundryup
-```
-Reload Your Shell Configuration or start another terminal instance:
-```bash
- source ~/.bashrc ## Replace this with your shell configuration file
- ```
-## Usage
-### Install Seismic Foundry as a Seismic core team member:
-```bash
-sfoundryup --core
-```
-**Tip**: All flags except `--core` have a single-character shorthand equivalent! You can use -v instead of --version, etc.
+**Tip**: All flags have a single-character shorthand equivalent! You can use -v instead of --version, etc.

--- a/sfoundryup/README.md
+++ b/sfoundryup/README.md
@@ -1,6 +1,5 @@
 # `sfoundryup`
 Install, update, or revert to a specific branch, fork, or version of Seismic Foundry tools with ease.
-## For developers building on top of Seismic
 ### Installing
 Run the following command to install sfoundryup:
 ```bash
@@ -31,6 +30,7 @@ source ~/.profile
 
 ## Usage
 ### Install Seismic Foundry:
+Run the following in your terminal to install the Seismic Foundry suite of developer tools:
 ```bash
 sfoundryup
 ```

--- a/sfoundryup/install
+++ b/sfoundryup/install
@@ -10,12 +10,6 @@ SEISMIC_BIN_DIR="$SEISMIC_DIR/bin"
 
 BIN_PATH="$SEISMIC_BIN_DIR/sfoundryup"
 
-# Ensure SEISMIC_PAT is set
-if [[ -z "$SEISMIC_PAT" ]]; then
-  echo "Error: SEISMIC_PAT environment variable is not set. Please export it with your GitHub Personal Access Token."
-  echo "Example: export SEISMIC_PAT=your_personal_access_token"
-  exit 1
-fi
 
 # GitHub raw URL to sfoundryup in the private repository
 RAW_API_URL="https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/sfoundryup/sfoundryup"
@@ -25,8 +19,7 @@ mkdir -p "$SEISMIC_BIN_DIR"
 
 # Download sfoundryup using GitHub raw content URL
 echo "Fetching sfoundryup from the private repository..."
-curl -sSf -H "Authorization: token $SEISMIC_PAT" \
-     "$RAW_API_URL" -o "$BIN_PATH"
+curl -sSf "$RAW_API_URL" -o "$BIN_PATH"
 
 # Make the file executable
 chmod +x "$BIN_PATH"

--- a/sfoundryup/sfoundryup
+++ b/sfoundryup/sfoundryup
@@ -171,17 +171,6 @@ install_from_remote_repo() {
   # Use the git CLI to fetch dependencies
   export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-  # if [[ "$SEISMIC_MODE" == "core" ]]; then
-  #  echo "Using SSH dependencies for Seismic core team members"
-  # else
-  #  echo "Using HTTPS dependencies for Seismic developers"
-  #  # For Seismic dependencies, remap the use of SSH to use HTTPS + access token
-  #  # First remove any previous remapping with old access token
-  #  ensure git config --global --get-regexp '^url\.https://.*@github\.com/SeismicSystems\.insteadOf' | cut -d' ' -f1 | while read -r key; do git config --global --unset "$key"; done || true
-  #  # Then add URL remapping
-  #  ensure git config --global url."https://$SEISMIC_PAT@github.com/SeismicSystems".insteadOf "ssh://git@github.com/SeismicSystems"
-  # fi
-
   # Build the binaries
   ensure cargo build --bins "${CARGO_BUILD_ARGS[@]}"
   for bin in "${BINS[@]}"; do

--- a/sfoundryup/sfoundryup
+++ b/sfoundryup/sfoundryup
@@ -12,12 +12,9 @@ BINS=(sforge scast sanvil schisel)
 export RUSTFLAGS="${RUSTFLAGS:--C target-cpu=native}"
 
 main() {
-  # Default to devs mode
-  SEISMIC_MODE="devs"
   while [[ -n $1 ]]; do
     case $1 in
       --)               shift; break;;
-      --core)           SEISMIC_MODE="core";;
       -v|--version)     shift; SEISMICUP_VERSION=$1;;
       -p|--path)        shift; SEISMICUP_LOCAL_REPO=$1;;
       -j|--jobs)        shift; SEISMICUP_JOBS=$1;;
@@ -33,15 +30,6 @@ main() {
     esac
     shift
   done
-
-  echo "SEISMIC_MODE: $SEISMIC_MODE"
-
-  # Ensure SEISMIC_PAT is set if not using seismic-core
-  if [[ -z "$SEISMIC_PAT" && "$SEISMIC_MODE" != "core" ]]; then
-    echo "Error: SEISMIC_PAT environment variable is not set. Please export it with your GitHub Personal Access Token."
-    echo "Example: export SEISMIC_PAT=your_personal_access_token"
-    exit 1
-  fi
 
   need_cmd git
   need_cmd curl
@@ -67,17 +55,6 @@ main() {
 
 install_ssolc() {
   echo "Starting ssolc installation..."
-
-  if [[ "$SEISMIC_MODE" == "core" ]]; then
-    echo "Please ensure you have 'ssolc' installed in /usr/local/bin."
-    return
-  fi
-
-  # Ensure SEISMIC_PAT is set
-  if [[ -z "$SEISMIC_PAT" ]]; then
-      echo "Error: SEISMIC_PAT environment variable is not set. Please provide a valid GitHub Personal Access Token."
-      exit 1
-  fi
 
   # Detect OS
   OS="$(uname -s)"
@@ -126,7 +103,7 @@ install_ssolc() {
   # Fetch the asset ID for the target file
   echo "Fetching asset ID for $TARGET_NAME..."
   GITHUB_API_URL="https://api.github.com/repos/SeismicSystems/seismic-solidity-releases/releases/latest"
-  ASSET_ID=$(curl -s -H "Authorization: token $SEISMIC_PAT" "$GITHUB_API_URL" | \
+  ASSET_ID=$(curl -s "$GITHUB_API_URL" | \
       jq -r --arg name "$TARGET_NAME" '.assets[] | select(.name == $name) | .id')
 
   if [[ -z "$ASSET_ID" ]]; then
@@ -138,8 +115,7 @@ install_ssolc() {
 
   # Download the file using the asset ID
   echo "Downloading $TARGET_NAME..."
-  curl -L -H "Authorization: token $SEISMIC_PAT" \
-       -H "Accept: application/octet-stream" \
+  curl -L -H "Accept: application/octet-stream" \
        -o "$TEMP_DIR/$TARGET_NAME" \
        "https://api.github.com/repos/SeismicSystems/seismic-solidity-releases/releases/assets/$ASSET_ID"
 
@@ -183,14 +159,8 @@ install_from_remote_repo() {
   # Clone the repository if it doesn't already exist
   if [ ! -d "$REPO_PATH" ]; then
     ensure mkdir -p "$SEISMIC_DIR"
-    say "Cloning the repository using PAT..."
-    if [[ "$SEISMIC_MODE" == "core" ]]; then
-    # Use SSH for core
-    ensure git clone "git@github.com:$SEISMICUP_REPO.git" "$REPO_PATH"
-    else
-    # Use HTTPS for devs
-    ensure git clone "https://$SEISMIC_PAT@github.com/$SEISMICUP_REPO.git" "$REPO_PATH"
-    fi
+    say "Cloning the repository..."
+    ensure git clone "https://github.com/$SEISMICUP_REPO.git" "$REPO_PATH"
   fi
 
   # Fetch and checkout the branch
@@ -201,16 +171,16 @@ install_from_remote_repo() {
   # Use the git CLI to fetch dependencies
   export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-  if [[ "$SEISMIC_MODE" == "core" ]]; then
-   echo "Using SSH dependencies for Seismic core team members"
-  else
-   echo "Using HTTPS dependencies for Seismic developers"
-   # For Seismic dependencies, remap the use of SSH to use HTTPS + access token
-   # First remove any previous remapping with old access token
-   ensure git config --global --get-regexp '^url\.https://.*@github\.com/SeismicSystems\.insteadOf' | cut -d' ' -f1 | while read -r key; do git config --global --unset "$key"; done || true
-   # Then add URL remapping
-   ensure git config --global url."https://$SEISMIC_PAT@github.com/SeismicSystems".insteadOf "ssh://git@github.com/SeismicSystems"
-  fi
+  # if [[ "$SEISMIC_MODE" == "core" ]]; then
+  #  echo "Using SSH dependencies for Seismic core team members"
+  # else
+  #  echo "Using HTTPS dependencies for Seismic developers"
+  #  # For Seismic dependencies, remap the use of SSH to use HTTPS + access token
+  #  # First remove any previous remapping with old access token
+  #  ensure git config --global --get-regexp '^url\.https://.*@github\.com/SeismicSystems\.insteadOf' | cut -d' ' -f1 | while read -r key; do git config --global --unset "$key"; done || true
+  #  # Then add URL remapping
+  #  ensure git config --global url."https://$SEISMIC_PAT@github.com/SeismicSystems".insteadOf "ssh://git@github.com/SeismicSystems"
+  # fi
 
   # Build the binaries
   ensure cargo build --bins "${CARGO_BUILD_ARGS[@]}"
@@ -236,7 +206,6 @@ USAGE:
     sfoundryup <OPTIONS>
 
 OPTIONS:
-    --core  Install Seismic Foundry for core Seismic team members (SSH dependencies)
     -h, --help      Print help information
     -v, --version   Install a specific version from built binaries
     -p, --path      Build and install a local repository


### PR DESCRIPTION
This PR introduces the following:
1. Completely removing the requirement for a personal access token (PAT) to install the Seismic dev tooling stack via the `install` and `sfoundryup` scripts now that everything has been open-sourced
2. Removing the two "modes" introduced earlier in order to facilitate separate dependency management for developers building on top of Seismic and the Seismic core team -- this too is no longer needed due to everything being open sourced