### PR TITLE
fix: `anvil` and `forge` terminal message to `sanvil` and `sforge`

### DIFF
--- a/crates/anvil/src/anvil.rs
+++ b/crates/anvil/src/anvil.rs
@@ -11,7 +11,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 /// A fast local Ethereum development node.
 #[derive(Parser)]
-#[command(name = "anvil", version = anvil::VERSION_MESSAGE, next_display_order = None)]
+#[command(name = "sanvil", version = anvil::VERSION_MESSAGE, next_display_order = None)]
 pub struct Anvil {
     /// Include the global options.
     #[command(flatten)]

--- a/crates/forge/bin/opts.rs
+++ b/crates/forge/bin/opts.rs
@@ -23,7 +23,7 @@ const VERSION_MESSAGE: &str = concat!(
 /// Build, test, fuzz, debug and deploy Solidity contracts.
 #[derive(Parser)]
 #[command(
-    name = "forge",
+    name = "sforge",
     version = VERSION_MESSAGE,
     after_help = "Find more information in the book: http://book.getfoundry.sh/reference/forge/forge.html",
     next_display_order = None,


### PR DESCRIPTION
This PR introduces the following:
1. Changes the terminal message when `<binary_name> --version` is run, from `anvil/forge` to `sanvil/sforge`. This is done by modifying the `#[command]` macro in the corresponding files for `sanvil` (`crates/anvil/src/anvil.rs`) and `sforge` (`crates/forge/bin/opts.rs`)