### PR TITLE
fix: rename `seismic-solidity-releases` -> `seismic-solidity` for `ssolc` binaries in `sfoundryup`

### DIFF
--- a/sfoundryup/sfoundryup
+++ b/sfoundryup/sfoundryup
@@ -105,7 +105,7 @@ install_ssolc() {
 
  # Download the release
  echo "Fetching latest release information..."
- GITHUB_API_URL="https://api.github.com/repos/SeismicSystems/seismic-solidity-releases/releases/latest"
+ GITHUB_API_URL="https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/latest"
  ASSET_ID=$(curl -s "$GITHUB_API_URL" | \
      jq -r --arg name "$TARGET_NAME" '.assets[] | select(.name == $name) | .id')
 


### PR DESCRIPTION
This PR introduces the following:
1. Renaming the URL for fetching `ssolc` binary releases from https://api.github.com/repos/SeismicSystems/seismic-solidity-releases/releases/latest to https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/latest since we now release binaries on the `seismic-solidity` repo itself and are archiving the `seismic-solidity-releases` repo.