### PR TITLE
fix: typos in `sfoundryup` and `install` scripts

### DIFF
--- a/sfoundryup/install
+++ b/sfoundryup/install
@@ -11,14 +11,14 @@ SEISMIC_BIN_DIR="$SEISMIC_DIR/bin"
 BIN_PATH="$SEISMIC_BIN_DIR/sfoundryup"
 
 
-# GitHub raw URL to sfoundryup in the private repository
+# GitHub raw URL to sfoundryup
 RAW_API_URL="https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/sfoundryup/sfoundryup"
 
 # Create necessary directories
 mkdir -p "$SEISMIC_BIN_DIR"
 
 # Download sfoundryup using GitHub raw content URL
-echo "Fetching sfoundryup from the private repository..."
+echo "Fetching sfoundryup..."
 curl -sSf "$RAW_API_URL" -o "$BIN_PATH"
 
 # Make the file executable

--- a/sfoundryup/sfoundryup
+++ b/sfoundryup/sfoundryup
@@ -118,7 +118,7 @@ install_ssolc() {
  DOWNLOAD_PATH="$TEMP_DIR/$TARGET_NAME"
  curl -L -H "Accept: application/octet-stream" \
       -o "$DOWNLOAD_PATH" \
-      "https://api.github.com/repos/SeismicSystems/seismic-solidity-releases/releases/assets/$ASSET_ID"
+      "https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/assets/$ASSET_ID"
 
  # Extract and install
  echo "Extracting archive..."


### PR DESCRIPTION
This PR introduces the following:
1. Some typo fixes in the `sfoundryup` and `install` scripts.