### PR TITLE
fix: build issue

### DIFF
--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -166,10 +166,11 @@ impl CoverageReporter for LcovReporter {
                         }
                     }
                     CoverageItemKind::Branch { branch_id, path_id, .. } => {
+                        let hits_str = if hits == 0 { "-".to_string() } else { hits.to_string() };
                         writeln!(
                             out,
                             "BRDA:{line},{branch_id},{path_id},{}",
-                            if hits == 0 { "-" } else { &hits.to_string() }
+                            hits_str
                         )?;
                     }
                 }

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -167,11 +167,7 @@ impl CoverageReporter for LcovReporter {
                     }
                     CoverageItemKind::Branch { branch_id, path_id, .. } => {
                         let hits_str = if hits == 0 { "-".to_string() } else { hits.to_string() };
-                        writeln!(
-                            out,
-                            "BRDA:{line},{branch_id},{path_id},{}",
-                            hits_str
-                        )?;
+                        writeln!(out, "BRDA:{line},{branch_id},{path_id},{}", hits_str)?;
                     }
                 }
             }


### PR DESCRIPTION
`cargo build --bins --release` fails with the following error:
```
   --> crates/forge/src/coverage.rs:172:58
    |
172 | ...                   if hits == 0 { "-" } else { &hits.to_string() }
    |                                                   -^^^^^^^^^^^^^^^-
    |                                                   ||              |
    |                                                   ||              temporary value is freed at the end of this statement
    |                                                   |creates a temporary value which is freed while still in use
    |                                                   borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value

For more information about this error, try `rustc --explain E0716`.
```

This PR fixes it so that `sfoundryup` (which uses the above command) doesn't fail