### PR TITLE
fix: seismic-hardfork to specid conversion

### DIFF
--- a/crates/anvil/src/hardfork.rs
+++ b/crates/anvil/src/hardfork.rs
@@ -6,6 +6,7 @@ use alloy_rpc_types::BlockNumberOrTag;
 
 use op_revm::OpSpecId;
 use revm::primitives::hardfork::SpecId;
+use seismic_prelude::foundry::SeismicSpecId;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ChainHardfork {
@@ -125,8 +126,9 @@ impl FromStr for SeismicHardfork {
 impl From<SeismicHardfork> for SpecId {
     fn from(fork: SeismicHardfork) -> Self {
         match fork {
-            SeismicHardfork::Mercury => Self::MERCURY,
-            SeismicHardfork::Latest => Self::MERCURY,
+            SeismicHardfork::Mercury | SeismicHardfork::Latest => {
+                SeismicSpecId::MERCURY.into()
+            }
         }
     }
 }

--- a/crates/anvil/src/hardfork.rs
+++ b/crates/anvil/src/hardfork.rs
@@ -126,9 +126,7 @@ impl FromStr for SeismicHardfork {
 impl From<SeismicHardfork> for SpecId {
     fn from(fork: SeismicHardfork) -> Self {
         match fork {
-            SeismicHardfork::Mercury | SeismicHardfork::Latest => {
-                SeismicSpecId::MERCURY.into()
-            }
+            SeismicHardfork::Mercury | SeismicHardfork::Latest => SeismicSpecId::MERCURY.into(),
         }
     }
 }


### PR DESCRIPTION
use .into() function to convert MERCURY to SpecId. This allows removing MERCURY from the specid, like we did in https://github.com/SeismicSystems/seismic-revm/pull/184

This will work for both current setup (where MERCURY is part of SpecID), and after we repoint revm to use the changes in seismic-revm. Opting to not point to the temporary reth-sdk as part of this PR, but might do it in a followup to test future changes.