### PR TITLE
feat(build): print ssolc commit when building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=5477a89ae892229a90af58580daa8ef4575f00a6#5477a89ae892229a90af58580daa8ef4575f00a6"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4689,7 +4689,7 @@ dependencies = [
  "foundry-compilers-core",
  "fs_extra",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "path-slash",
  "rand 0.9.2",
  "rayon",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=5477a89ae892229a90af58580daa8ef4575f00a6#5477a89ae892229a90af58580daa8ef4575f00a6"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -4720,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=5477a89ae892229a90af58580daa8ef4575f00a6#5477a89ae892229a90af58580daa8ef4575f00a6"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=5477a89ae892229a90af58580daa8ef4575f00a6#5477a89ae892229a90af58580daa8ef4575f00a6"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=5477a89ae892229a90af58580daa8ef4575f00a6#5477a89ae892229a90af58580daa8ef4575f00a6"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
 dependencies = [
  "alloy-primitives",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,10 +412,10 @@ alloy-op-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev 
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "039d51496b9b9a0cb4fea6d606e472211b462073" }
 
 # foundry
-foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "5477a89ae892229a90af58580daa8ef4575f00a6" }
-foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "5477a89ae892229a90af58580daa8ef4575f00a6" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "5477a89ae892229a90af58580daa8ef4575f00a6" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "5477a89ae892229a90af58580daa8ef4575f00a6" }
-foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "5477a89ae892229a90af58580daa8ef4575f00a6" }
+foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
+foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
+foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
 
 foundry-fork-db = { git = "https://github.com/SeismicSystems/seismic-foundry-fork-db.git", rev = "e5fb1f8838b517dbaaccc08a8af6767fe2e70c4e" }

--- a/crates/common/src/term.rs
+++ b/crates/common/src/term.rs
@@ -1,7 +1,7 @@
 //! terminal utils
 use foundry_compilers::{
     artifacts::remappings::Remapping,
-    report::{self, BasicStdoutReporter, Reporter},
+    report::{self, BasicStdoutReporter, Reporter, format_version_with_commit},
 };
 use foundry_config::find_project_root;
 use itertools::Itertools;
@@ -177,19 +177,18 @@ impl Reporter for SpinnerReporter {
         }
 
         self.send_msg(format!(
-            "Compiling {} files with {} {}.{}.{}",
+            "Compiling {} files with {} {}",
             dirty_files.len(),
             compiler_name,
-            version.major,
-            version.minor,
-            version.patch
+            format_version_with_commit(version),
         ));
     }
 
     fn on_compiler_success(&self, compiler_name: &str, version: &Version, duration: &Duration) {
         self.send_msg(format!(
-            "{} {}.{}.{} finished in {duration:.2?}",
-            compiler_name, version.major, version.minor, version.patch
+            "{} {} finished in {duration:.2?}",
+            compiler_name,
+            format_version_with_commit(version),
         ));
     }
 


### PR DESCRIPTION
Uses https://github.com/SeismicSystems/seismic-compilers/pull/14

When compiling with -vvv we can now see the commit version:
```
$ sforge build -vvv
[⠊] Compiling...
[⠑] Compiling 44 files with ssolc 0.8.31 (676bdec)
[⠘] ssolc 0.8.31 (676bdec) finished in 615.21ms
```

Before we'd see `Compiler ... with Solc 0.8.31` only.