### PR TITLE
chore: update seismic-compiler version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -4720,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=d24431fcbdc3b7a05e8657e76d56f5b8533cef0c#d24431fcbdc3b7a05e8657e76d56f5b8533cef0c"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
 dependencies = [
  "alloy-primitives",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 # If our dependencies depend on these things,
 # then this will override whatever versions they point to
 # and instead use our local version
-seismic-enclave =  { git = "https://github.com/SeismicSystems/enclave.git", rev = "ac5e28dac1ee8ec0e3922b010e6da072d6e784aa" }
+seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "ac5e28dac1ee8ec0e3922b010e6da072d6e784aa" }
 
 # seismic-alloy-core
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
@@ -412,10 +412,10 @@ alloy-op-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev 
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "039d51496b9b9a0cb4fea6d606e472211b462073" }
 
 # foundry
-foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
-foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
-foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "d24431fcbdc3b7a05e8657e76d56f5b8533cef0c" }
+foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
+foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
+foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
 
 foundry-fork-db = { git = "https://github.com/SeismicSystems/seismic-foundry-fork-db.git", rev = "e5fb1f8838b517dbaaccc08a8af6767fe2e70c4e" }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -538,7 +538,12 @@ pub struct Config {
 
     /// Seismic field (default: true)
     ///
-    /// Used for purposes of specifying Seismic-Solidity (solc)
+    /// When set to true, ssolc (seismic-solidity compiler) will be used instead of solc.
+    ///
+    /// TODO(samlaf): do we really need this? The compiler could be chosen purely based off of
+    /// evm_version config value (if mercury, use ssolc; else use solc).
+    /// Also should we just rename this to `use_ssolc` instead of seismic, which is a bit confusing
+    /// because it looks like it might also be used to configure execution (tests, anvil, etc).
     pub seismic: bool,
 
     /// Warnings gathered when loading the Config. See [`WarningsProvider`] for more information.
@@ -916,8 +921,12 @@ impl Config {
         config
     }
 
-    // Turn on seismic flag if evm version is seismic. For now this logic works.
+    // This is called on every foundry.toml config files right now, including on lib/ configs.
+    // TODO(samlaf): this might have weird side effects at some point if our library ecosystem
+    // grows.
     pub fn sanitize_seismic_settings(&mut self) {
+        // If Mercury feature set is required, then use seismic-compiler (self.seismic controls
+        // which compiler is used).
         if self.evm_version == EvmVersion::Mercury {
             self.seismic = true;
         }
@@ -2398,7 +2407,7 @@ impl Default for Config {
             gas_reports: vec!["*".to_string()],
             gas_reports_ignore: vec![],
             gas_reports_include_tests: false,
-            solc: Some(SolcReq::Version(Version::parse("0.8.30").unwrap())),
+            solc: Some(SolcReq::Version(Version::parse("0.8.31").unwrap())),
             vyper: Default::default(),
             auto_detect_solc: true,
             offline: false,


### PR DESCRIPTION
This updates the compiler print to be able to tell whcih exact ssolc commit is used.

This brings in https://github.com/SeismicSystems/seismic-compilers/commit/5a398fffdaee1ed6092871a1ef1beb131b5d1ca6
Also added some comments to explain how the `seismic` config field works as I got confused about what the code was doing.