### PR TITLE
ci: enable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,29 +93,29 @@ jobs:
           # `target`: Rust build target triple
           # `platform` and `arch`: Used in tarball names
           # `svm`: target platform to use for the Solc binary: https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
-          - runner: Linux-22.04
+          - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             svm_target_platform: linux-amd64
             platform: linux
             arch: amd64
-          - runner: Linux-22.04
-            target: x86_64-unknown-linux-musl
-            svm_target_platform: linux-amd64
-            platform: alpine
-            arch: amd64
-          - runner: Linux-22.04
+          # Turning off musl since afaiu this is only needed when running inside Alpine Docker containers,
+          # which we don't even support atm.
+          # - runner: ubuntu-22.04
+          #   target: x86_64-unknown-linux-musl
+          #   svm_target_platform: linux-amd64
+          #   platform: alpine
+          #   arch: amd64
+          - runner: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             svm_target_platform: linux-aarch64
             platform: linux
             arch: arm64
-          - runner: Linux-22.04
-            target: aarch64-unknown-linux-musl
-            svm_target_platform: linux-aarch64
-            platform: alpine
-            arch: arm64
-          # This is pinned to `macos-13-large` to support old SDK versions.
-          # If the runner is deprecated it should be pinned to the oldest available version of the runner.
-          - runner: macos-13-large
+          # - runner: ubuntu-22.04
+          #   target: aarch64-unknown-linux-musl
+          #   svm_target_platform: linux-aarch64
+          #   platform: alpine
+          #   arch: arm64
+          - runner: macos-14-large
             target: x86_64-apple-darwin
             svm_target_platform: macosx-amd64
             platform: darwin
@@ -125,11 +125,12 @@ jobs:
             svm_target_platform: macosx-aarch64
             platform: darwin
             arch: arm64
-          - runner: Windows
-            target: x86_64-pc-windows-msvc
-            svm_target_platform: windows-amd64
-            platform: win32
-            arch: amd64
+          # Turning off Windows for now since I don't think we have any usecase for it.
+          # - runner: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   svm_target_platform: windows-amd64
+          #   platform: win32
+          #   arch: amd64
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,11 +105,14 @@ jobs:
           #   svm_target_platform: linux-amd64
           #   platform: alpine
           #   arch: amd64
-          - runner: ubuntu-22.04-arm
-            target: aarch64-unknown-linux-gnu
-            svm_target_platform: linux-aarch64
-            platform: linux
-            arch: arm64
+          # Note(samlaf): turning off ubuntu arm runners for now since the build is oom'ing and crashing, despite having 16GiB of RAM.
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+          # Not sure why the arm builds take so much more memory, but anyways we don't need these builds for now until there's user demand.
+          # - runner: ubuntu-22.04-arm
+          #   target: aarch64-unknown-linux-gnu
+          #   svm_target_platform: linux-aarch64
+          #   platform: linux
+          #   arch: arm64
           # - runner: ubuntu-22.04
           #   target: aarch64-unknown-linux-musl
           #   svm_target_platform: linux-aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   #     - "rc-*"
   #     - "v*.*.*"
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           #   svm_target_platform: linux-amd64
           #   platform: alpine
           #   arch: amd64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             svm_target_platform: linux-aarch64
             platform: linux
@@ -148,7 +148,7 @@ jobs:
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
       - name: cross setup
-        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-gnu'
+        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'
         run: |
           cargo install cross
 
@@ -172,7 +172,7 @@ jobs:
 
           [[ "$TARGET" == *windows* ]] && ext=".exe"
 
-          if [[ "$TARGET" == *-musl || "$TARGET" == "aarch64-unknown-linux-gnu" ]]; then
+          if [[ "$TARGET" == *-musl ]]; then
             cross build "${flags[@]}"
           else
             cargo build "${flags[@]}"

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2256,7 +2256,12 @@ impl Backend {
                         let result = evm.transact(env.tx.clone())?;
                         let res = evm
                             .inspector_mut()
-                            .json_result(result, &env.tx.into_tx_env(), &block, &cache_db)
+                            .json_result(
+                                result,
+                                &alloy_evm::IntoTxEnv::<TxEnv>::into_tx_env(env.tx),
+                                &block,
+                                &cache_db,
+                            )
                             .map_err(|err| BlockchainError::Message(err.to_string()))?;
 
                         Ok(GethTrace::JS(res))
@@ -3047,7 +3052,7 @@ impl Backend {
         let trace = inspector
             .json_result(
                 result,
-                &alloy_evm::IntoTxEnv::into_tx_env(tx_env),
+                &alloy_evm::IntoTxEnv::<TxEnv>::into_tx_env(tx_env),
                 &env.evm_env.block_env,
                 &cache_db,
             )


### PR DESCRIPTION
Ran the workflow manually and it succeeded: https://github.com/SeismicSystems/seismic-foundry/actions/runs/22312870726

Set it to:
- make a release once a week (or whenever manually triggered)
- build for 3 platforms (ubuntu-x86, mac-x86, mac-arm). Disabled all the others because had issues with github's self hosted runners, plus I don't think there's demand at this point in time