### PR TITLE
feat(solc-config): add support for unsafe-via-ir option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ _
 .vercel
 .vite
 .wrangler
-build
+/build
 *.zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4689,7 +4689,7 @@ dependencies = [
  "foundry-compilers-core",
  "fs_extra",
  "futures-util",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "path-slash",
  "rand 0.9.2",
  "rayon",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -4720,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=bbb38d77478f2d30013d5d5956ead23b520fd358#bbb38d77478f2d30013d5d5956ead23b520fd358"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
 dependencies = [
  "alloy-primitives",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,10 +412,10 @@ alloy-op-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev 
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "039d51496b9b9a0cb4fea6d606e472211b462073" }
 
 # foundry
-foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
-foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
-foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "bbb38d77478f2d30013d5d5956ead23b520fd358" }
+foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
+foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
+foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
 
 foundry-fork-db = { git = "https://github.com/SeismicSystems/seismic-foundry-fork-db.git", rev = "e5fb1f8838b517dbaaccc08a8af6767fe2e70c4e" }

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -82,6 +82,11 @@ pub struct BuildOpts {
     #[serde(skip)]
     pub via_ir: bool,
 
+    /// Allow via-IR pipeline on Seismic's ssolc (experimental).
+    #[arg(long, help_heading = "Compiler options")]
+    #[serde(skip)]
+    pub unsafe_via_ir: bool,
+
     /// Changes compilation to only use literal content and not URLs.
     #[arg(long, help_heading = "Compiler options")]
     #[serde(skip)]
@@ -225,6 +230,10 @@ impl Provider for BuildOpts {
 
         if self.via_ir {
             dict.insert("via_ir".to_string(), true.into());
+        }
+
+        if self.unsafe_via_ir {
+            dict.insert("unsafe_via_ir".to_string(), true.into());
         }
 
         if self.use_literal_content {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1625,9 +1625,10 @@ impl Config {
             }),
             model_checker,
             via_ir: Some(self.via_ir),
-            // Only send when its explicitly set to true, since we plan for this option to be temporary,
-            // and so we want to remain backward and forward compatible with other ssolc compilers
-            // that might not recognize the option (hence sending false would break for no reason).
+            // Only send when its explicitly set to true, since we plan for this option to be
+            // temporary, and so we want to remain backward and forward compatible with
+            // other ssolc compilers that might not recognize the option (hence sending
+            // false would break for no reason).
             unsafe_via_ir: self.unsafe_via_ir.then_some(true),
             // Not used.
             stop_after: None,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1625,7 +1625,10 @@ impl Config {
             }),
             model_checker,
             via_ir: Some(self.via_ir),
-            unsafe_via_ir: Some(self.unsafe_via_ir),
+            // Only send when its explicitly set to true, since we plan for this option to be temporary,
+            // and so we want to remain backward and forward compatible with other ssolc compilers
+            // that might not recognize the option (hence sending false would break for no reason).
+            unsafe_via_ir: self.unsafe_via_ir.then_some(true),
             // Not used.
             stop_after: None,
             // Set in project paths.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -433,6 +433,8 @@ pub struct Config {
     /// If set to true, changes compilation pipeline to go through the Yul intermediate
     /// representation.
     pub via_ir: bool,
+    /// Allow via-IR pipeline on Seismic's ssolc (experimental, shielded type support incomplete).
+    pub unsafe_via_ir: bool,
     /// Whether to include the AST as JSON in the compiler output.
     pub ast: bool,
     /// RPC storage caching settings determines what chains and endpoints to cache
@@ -1623,6 +1625,7 @@ impl Config {
             }),
             model_checker,
             via_ir: Some(self.via_ir),
+            unsafe_via_ir: Some(self.unsafe_via_ir),
             // Not used.
             stop_after: None,
             // Set in project paths.
@@ -2472,6 +2475,7 @@ impl Default for Config {
             ignored_file_paths: vec![],
             deny_warnings: false,
             via_ir: false,
+            unsafe_via_ir: false,
             ast: false,
             rpc_storage_caching: Default::default(),
             rpc_endpoints: Default::default(),

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -136,6 +136,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         ignored_file_paths: vec![],
         deny_warnings: false,
         via_ir: true,
+        unsafe_via_ir: false,
         ast: false,
         rpc_storage_caching: StorageCachingConfig {
             chains: CachedChains::None,


### PR DESCRIPTION
Adding option to pass --unsafe-via-ir option down to ssolc.
This updates the seismic-compiler to get the similar changes from https://github.com/SeismicSystems/seismic-compilers/pull/18

Needed because versions of ssolc (https://github.com/SeismicSystems/seismic-solidity/pull/204) require --unsafe-via-ir argument, which foundry's config didn't support before this. Now one can change foundry.toml to have
```
via_ir = true
unsafe_via_ir = true
```
and both of these will be passed down to ssolc.

chore: Also fixed .gitignore since it was ignoring crates/cli/src/opts/build by mistake.