### PR TITLE
Fix block.timestamp units in sanvil

### DIFF
--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -486,7 +486,8 @@ async fn get_blocktimestamp_works() {
 
     let timestamp = contract.getCurrentBlockTimestamp().call().await.unwrap();
 
-    assert!(timestamp > U256::from(1));
+    let ts = timestamp.to::<u64>();
+    assert!(ts >= 1_000_000_000 && ts < 10_000_000_000);
 
     let latest_block =
         api.block_by_number(alloy_rpc_types::BlockNumberOrTag::Latest).await.unwrap().unwrap();

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -558,7 +558,7 @@ impl Cheatcode for txGasPriceCall {
 impl Cheatcode for warpCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newTimestamp } = self;
-        ccx.ecx.block.timestamp = *newTimestamp * U256::from(1000); // convert to milliseconds
+        ccx.ecx.block.timestamp = *newTimestamp;
         Ok(Default::default())
     }
 }
@@ -566,7 +566,7 @@ impl Cheatcode for warpCall {
 impl Cheatcode for getBlockTimestampCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
-        Ok((ccx.ecx.block.timestamp / U256::from(1000)).abi_encode()) // convert to seconds since we return block.timestamp in milliseconds
+        Ok(ccx.ecx.block.timestamp.abi_encode())
     }
 }
 

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 seismic-prelude.workspace = true
-alloy-seismic-evm.workspace = true
+alloy-seismic-evm = { workspace = true, features = ["timestamp-in-seconds"] }
 
 foundry-cheatcodes-spec.workspace = true
 foundry-common.workspace = true


### PR DESCRIPTION
## Summary
- A critical and embarassing bug: `block.timestamp` was returning (correctValue) / 1000

## AI comments
- Enable "timestamp-in-seconds" for seismic EVM so TIMESTAMP reports seconds
- Align vm.warp/getBlockTimestamp to seconds