### PR TITLE
test + fmt: RNG precompile tx_hash propagation

### DIFF
--- a/crates/anvil/tests/it/seismic.rs
+++ b/crates/anvil/tests/it/seismic.rs
@@ -355,112 +355,30 @@ async fn test_seismic_rng_different_per_transaction() {
     .unwrap();
     let deployer = handle.dev_accounts().next().unwrap();
 
-    // Deploy a minimal contract that:
-    //   - On any call: STATICCALL the RNG precompile (0x64) requesting 32 bytes
-    //   - Stores the result in storage slot 0
-    //   - Increments a call counter in storage slot 1
-    //   - Returns the RNG result
+    // Minimal contract: on any call, STATICCALLs the RNG precompile (0x64)
+    // requesting 32 random bytes, stores the result in slot 0, increments a
+    // call counter in slot 1, and returns the result.
     //
     // Solidity equivalent:
     //   contract RngCaller {
     //       bytes32 public lastRng;
     //       uint256 public callCount;
     //       fallback() external {
-    //           // Prepare input: 0x00000020 (32 bytes)
-    //           bytes memory input = hex"00000020";
-    //           (bool ok, bytes memory result) = address(0x64).staticcall(input);
+    //           (bool ok, bytes memory result) = address(0x64).staticcall(hex"00000020");
     //           require(ok);
     //           lastRng = bytes32(result);
     //           callCount++;
-    //           // Return the result
     //           assembly { return(add(result, 32), mload(result)) }
     //       }
     //   }
     //
-    // Hand-assembled EVM bytecode for the runtime code:
-    //   PUSH4 0x00000020  ; numBytes = 32
-    //   PUSH0             ; memory offset 0
-    //   MSTORE            ; mem[0..32] = 0x00000020 (right-padded)
-    //   PUSH1 0x20        ; retSize = 32
-    //   PUSH1 0x00        ; retOffset = 0
-    //   PUSH1 0x04        ; argSize = 4 (first 4 bytes of memory = 00000020)
-    //   PUSH1 0x1c        ; argOffset = 28 (bytes 28..32 of the word contain 00000020)
-    //   PUSH1 0x64        ; address = 0x64 (RNG precompile)
-    //   GAS               ; forward all gas
-    //   STATICCALL         ; staticcall(gas, 0x64, 28, 4, 0, 32)
-    //   POP               ; discard success flag
-    //   PUSH0             ; offset 0
-    //   MLOAD             ; load result from memory
-    //   DUP1              ; duplicate for storage
-    //   PUSH0             ; slot 0
-    //   SSTORE            ; store lastRng
-    //   PUSH1 0x01        ; slot 1
-    //   SLOAD             ; load callCount
-    //   PUSH1 0x01        ; increment
-    //   ADD
-    //   PUSH1 0x01        ; slot 1
-    //   SSTORE            ; store callCount
-    //   PUSH0             ; memory offset 0
-    //   MSTORE            ; store result in memory for return
-    //   PUSH1 0x20        ; return 32 bytes
-    //   PUSH0             ; from offset 0
-    //   RETURN
-    // Runtime bytecodes concatenated into one hex string.
-    // See comments above for opcode breakdown.
-    // Uses PUSH1 0x00 instead of PUSH0 (0x5f) for compatibility.
-    let runtime_code = hex::decode(concat!(
-        "6300000020", // PUSH4 0x00000020
-        "6000",       // PUSH1 0x00
-        "52",         // MSTORE
-        "6020",       // PUSH1 0x20 (retSize)
-        "6000",       // PUSH1 0x00 (retOffset)
-        "6004",       // PUSH1 0x04 (argSize)
-        "601c",       // PUSH1 0x1c (argOffset = 28)
-        "6064",       // PUSH1 0x64 (RNG precompile address)
-        "5a",         // GAS
-        "fa",         // STATICCALL
-        "50",         // POP (discard success)
-        "6000",       // PUSH1 0x00
-        "51",         // MLOAD (load RNG result)
-        "80",         // DUP1
-        "6000",       // PUSH1 0x00
-        "55",         // SSTORE (slot 0 = result)
-        "6001",       // PUSH1 0x01
-        "54",         // SLOAD (load counter)
-        "6001",       // PUSH1 0x01
-        "01",         // ADD
-        "6001",       // PUSH1 0x01
-        "55",         // SSTORE (slot 1 = counter)
-        "6000",       // PUSH1 0x00
-        "52",         // MSTORE
-        "6020",       // PUSH1 0x20
-        "6000",       // PUSH1 0x00
-        "f3",         // RETURN
-    ))
+    // Bytecode: 12-byte deploy prefix + 45-byte runtime.
+    let deploy_code = hex::decode(
+        "602d600c600039602d6000f3\
+         6300000020600052602060006004601c60645afa50600051806000556001546001016001556000526020\
+         6000f3",
+    )
     .unwrap();
-
-    // Deploy prefix: CODECOPY runtime to memory, then RETURN it.
-    // The prefix is exactly 12 bytes, so runtime starts at offset 12.
-    // CODECOPY pops (destOffset, offset, size) — push in reverse order.
-    // RETURN pops (offset, size) — push in reverse order.
-    let runtime_len = runtime_code.len() as u8;
-    let mut deploy_code: Vec<u8> = vec![
-        0x60,
-        runtime_len, // PUSH1 <size>
-        0x60,
-        0x0c, // PUSH1 0x0c (offset = 12, where runtime starts in deploy code)
-        0x60,
-        0x00, // PUSH1 0x00 (destOffset in memory)
-        0x39, // CODECOPY(destOffset=0, offset=12, size=runtime_len)
-        0x60,
-        runtime_len, // PUSH1 <size>
-        0x60,
-        0x00, // PUSH1 0x00 (offset)
-        0xf3, // RETURN(offset=0, size=runtime_len)
-    ];
-    assert_eq!(deploy_code.len(), 12, "deploy prefix must be exactly 12 bytes");
-    deploy_code.extend_from_slice(&runtime_code);
-
     let bytecode = Bytes::from(deploy_code);
     let tx_req =
         tx_builder().with_from(deployer).with_kind(TxKind::Create).with_input(bytecode).into();
@@ -474,22 +392,13 @@ async fn test_seismic_rng_different_per_transaction() {
         .contract_address
         .unwrap();
 
-    // Deploy a second instance of the same contract
-    let mut deploy_code_2 = vec![
-        0x60,
-        runtime_len, // PUSH1 size
-        0x60,
-        0x0c, // PUSH1 offset (12 = deploy prefix length)
-        0x60,
-        0x00, // PUSH1 destOffset
-        0x39, // CODECOPY
-        0x60,
-        runtime_len, // PUSH1 size
-        0x60,
-        0x00, // PUSH1 offset
-        0xf3, // RETURN
-    ];
-    deploy_code_2.extend_from_slice(&runtime_code);
+    // Deploy a second instance of the same contract (identical bytecode)
+    let deploy_code_2 = hex::decode(
+        "602d600c600039602d6000f3\
+         6300000020600052602060006004601c60645afa50600051806000556001546001016001556000526020\
+         6000f3",
+    )
+    .unwrap();
     let contract_addr_2 = provider
         .send_transaction(
             tx_builder()

--- a/crates/anvil/tests/it/seismic.rs
+++ b/crates/anvil/tests/it/seismic.rs
@@ -445,13 +445,18 @@ async fn test_seismic_rng_different_per_transaction() {
     // RETURN pops (offset, size) — push in reverse order.
     let runtime_len = runtime_code.len() as u8;
     let mut deploy_code: Vec<u8> = vec![
-        0x60, runtime_len, // PUSH1 <size>
-        0x60, 0x0c,        // PUSH1 0x0c (offset = 12, where runtime starts in deploy code)
-        0x60, 0x00,        // PUSH1 0x00 (destOffset in memory)
-        0x39,              // CODECOPY(destOffset=0, offset=12, size=runtime_len)
-        0x60, runtime_len, // PUSH1 <size>
-        0x60, 0x00,        // PUSH1 0x00 (offset)
-        0xf3,              // RETURN(offset=0, size=runtime_len)
+        0x60,
+        runtime_len, // PUSH1 <size>
+        0x60,
+        0x0c, // PUSH1 0x0c (offset = 12, where runtime starts in deploy code)
+        0x60,
+        0x00, // PUSH1 0x00 (destOffset in memory)
+        0x39, // CODECOPY(destOffset=0, offset=12, size=runtime_len)
+        0x60,
+        runtime_len, // PUSH1 <size>
+        0x60,
+        0x00, // PUSH1 0x00 (offset)
+        0xf3, // RETURN(offset=0, size=runtime_len)
     ];
     assert_eq!(deploy_code.len(), 12, "deploy prefix must be exactly 12 bytes");
     deploy_code.extend_from_slice(&runtime_code);
@@ -471,13 +476,18 @@ async fn test_seismic_rng_different_per_transaction() {
 
     // Deploy a second instance of the same contract
     let mut deploy_code_2 = vec![
-        0x60, runtime_len, // PUSH1 size
-        0x60, 0x0c,        // PUSH1 offset (12 = deploy prefix length)
-        0x60, 0x00,        // PUSH1 destOffset
-        0x39,              // CODECOPY
-        0x60, runtime_len, // PUSH1 size
-        0x60, 0x00,        // PUSH1 offset
-        0xf3,              // RETURN
+        0x60,
+        runtime_len, // PUSH1 size
+        0x60,
+        0x0c, // PUSH1 offset (12 = deploy prefix length)
+        0x60,
+        0x00, // PUSH1 destOffset
+        0x39, // CODECOPY
+        0x60,
+        runtime_len, // PUSH1 size
+        0x60,
+        0x00, // PUSH1 offset
+        0xf3, // RETURN
     ];
     deploy_code_2.extend_from_slice(&runtime_code);
     let contract_addr_2 = provider

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1206,55 +1206,23 @@ mod tests {
         let caller = Address::repeat_byte(0x01);
         executor.set_balance(caller, U256::MAX).unwrap();
 
-        // Runtime bytecode: calls RNG precompile (0x64) requesting 32 bytes,
-        // stores result in slot 0, returns it.
+        // Minimal contract that calls the RNG precompile (0x64), requesting 32
+        // random bytes, stores the result in slot 0, and returns it.
         //
-        // Equivalent Solidity:
+        // Solidity equivalent:
         //   fallback() external {
         //       (bool ok, bytes memory result) = address(0x64).staticcall(hex"00000020");
         //       assembly { sstore(0, mload(add(result, 32))) }
         //       assembly { return(0, 32) }
         //   }
-        let runtime_code: Vec<u8> = vec![
-            0x63, 0x00, 0x00, 0x00, 0x20, // PUSH4 0x00000020
-            0x60, 0x00, // PUSH1 0x00
-            0x52, // MSTORE
-            0x60, 0x20, // PUSH1 0x20 (retSize)
-            0x60, 0x00, // PUSH1 0x00 (retOffset)
-            0x60, 0x04, // PUSH1 0x04 (argSize)
-            0x60, 0x1c, // PUSH1 0x1c (argOffset = 28)
-            0x60, 0x64, // PUSH1 0x64 (RNG precompile)
-            0x5a, // GAS
-            0xfa, // STATICCALL
-            0x50, // POP (discard success flag)
-            // mem[0..32] now contains the RNG result
-            0x60, 0x00, // PUSH1 0x00
-            0x51, // MLOAD (load RNG result onto stack)
-            0x60, 0x00, // PUSH1 0x00
-            0x55, // SSTORE (slot 0 = result)
-            // Return the 32 bytes already in memory
-            0x60, 0x20, // PUSH1 0x20
-            0x60, 0x00, // PUSH1 0x00
-            0xf3, // RETURN
-        ];
-
-        // Deploy prefix: CODECOPY runtime to memory, then RETURN it.
-        let runtime_len = runtime_code.len() as u8;
-        let mut deploy_code: Vec<u8> = vec![
-            0x60,
-            runtime_len, // PUSH1 <size>
-            0x60,
-            0x0c, // PUSH1 0x0c (offset = 12)
-            0x60,
-            0x00, // PUSH1 0x00 (destOffset)
-            0x39, // CODECOPY
-            0x60,
-            runtime_len, // PUSH1 <size>
-            0x60,
-            0x00, // PUSH1 0x00
-            0xf3, // RETURN
-        ];
-        deploy_code.extend_from_slice(&runtime_code);
+        //
+        // The deploy prefix (first 12 bytes) CODECOPYs the runtime to memory
+        // and RETURNs it.
+        let deploy_code = alloy_primitives::hex::decode(
+            // deploy prefix (12 bytes) + runtime (32 bytes)
+            "6020600c60003960206000f36300000020600052602060006004601c60645afa5060005160005560206000f3",
+        )
+        .unwrap();
 
         let deploy_result =
             executor.deploy(caller, Bytes::from(deploy_code), U256::ZERO, None).unwrap();

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_primitives::{
-    Address, Bytes, Log, TxKind, U256, keccak256,
+    Address, B256, Bytes, Log, TxKind, U256, keccak256,
     map::{AddressHashMap, HashMap},
 };
 use alloy_sol_types::{SolCall, sol};
@@ -1181,5 +1181,119 @@ impl FailFast {
     /// Whether a failure has been recorded and test should stop.
     pub fn should_stop(&self) -> bool {
         self.inner.as_ref().map(|flag| flag.load(Ordering::Relaxed)).unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests that the RNG precompile produces different output across separate transactions
+    /// when executed through the foundry-evm Executor (no anvil required).
+    ///
+    /// Deploys a minimal contract that calls the RNG precompile (0x64) and stores the
+    /// 32-byte result in storage slot 0. Three separate `transact_raw` calls should each
+    /// produce a different RNG value because each transaction should have a unique tx_hash
+    /// used as the RNG seed.
+    #[test]
+    fn test_rng_precompile_different_per_tx() {
+        let backend = Backend::spawn(None).unwrap();
+        let mut env = Env::default_with_spec_id(SpecId::MERCURY);
+        env.evm_env.cfg_env.disable_nonce_check = true;
+        let mut executor =
+            ExecutorBuilder::new().spec_id(SpecId::MERCURY).gas_limit(u64::MAX).build(env, backend);
+
+        let caller = Address::repeat_byte(0x01);
+        executor.set_balance(caller, U256::MAX).unwrap();
+
+        // Runtime bytecode: calls RNG precompile (0x64) requesting 32 bytes,
+        // stores result in slot 0, returns it.
+        //
+        // Equivalent Solidity:
+        //   fallback() external {
+        //       (bool ok, bytes memory result) = address(0x64).staticcall(hex"00000020");
+        //       assembly { sstore(0, mload(add(result, 32))) }
+        //       assembly { return(0, 32) }
+        //   }
+        let runtime_code: Vec<u8> = vec![
+            0x63, 0x00, 0x00, 0x00, 0x20, // PUSH4 0x00000020
+            0x60, 0x00, // PUSH1 0x00
+            0x52, // MSTORE
+            0x60, 0x20, // PUSH1 0x20 (retSize)
+            0x60, 0x00, // PUSH1 0x00 (retOffset)
+            0x60, 0x04, // PUSH1 0x04 (argSize)
+            0x60, 0x1c, // PUSH1 0x1c (argOffset = 28)
+            0x60, 0x64, // PUSH1 0x64 (RNG precompile)
+            0x5a, // GAS
+            0xfa, // STATICCALL
+            0x50, // POP (discard success flag)
+            // mem[0..32] now contains the RNG result
+            0x60, 0x00, // PUSH1 0x00
+            0x51, // MLOAD (load RNG result onto stack)
+            0x60, 0x00, // PUSH1 0x00
+            0x55, // SSTORE (slot 0 = result)
+            // Return the 32 bytes already in memory
+            0x60, 0x20, // PUSH1 0x20
+            0x60, 0x00, // PUSH1 0x00
+            0xf3, // RETURN
+        ];
+
+        // Deploy prefix: CODECOPY runtime to memory, then RETURN it.
+        let runtime_len = runtime_code.len() as u8;
+        let mut deploy_code: Vec<u8> = vec![
+            0x60,
+            runtime_len, // PUSH1 <size>
+            0x60,
+            0x0c, // PUSH1 0x0c (offset = 12)
+            0x60,
+            0x00, // PUSH1 0x00 (destOffset)
+            0x39, // CODECOPY
+            0x60,
+            runtime_len, // PUSH1 <size>
+            0x60,
+            0x00, // PUSH1 0x00
+            0xf3, // RETURN
+        ];
+        deploy_code.extend_from_slice(&runtime_code);
+
+        let deploy_result =
+            executor.deploy(caller, Bytes::from(deploy_code), U256::ZERO, None).unwrap();
+        let contract = deploy_result.address;
+
+        // Call the contract 3 times, each with a unique tx_hash to simulate
+        // distinct transactions. Without setting tx_hash, it defaults to
+        // B256::ZERO and the RNG precompile produces identical output.
+        let mut rng_values = Vec::new();
+        for i in 0..3 {
+            let mut env =
+                executor.build_test_env(caller, TxKind::Call(contract), Bytes::new(), U256::ZERO);
+            env.tx.tx_hash = B256::random();
+            let result = executor.transact_with_env(env).unwrap();
+            assert!(
+                !result.reverted,
+                "RNG call {i} should not revert: exit={:?} result={}",
+                result.exit_reason,
+                alloy_primitives::hex::encode(&result.result)
+            );
+            assert_eq!(result.result.len(), 32, "should return 32 bytes");
+            rng_values.push(result.result.clone());
+        }
+
+        // All three RNG values should be non-zero and distinct
+        for (i, val) in rng_values.iter().enumerate() {
+            assert_ne!(val.as_ref(), &[0u8; 32], "RNG output {i} should not be zero");
+        }
+        assert_ne!(
+            rng_values[0], rng_values[1],
+            "RNG outputs 0 and 1 should differ (tx_hash not propagated?)"
+        );
+        assert_ne!(
+            rng_values[1], rng_values[2],
+            "RNG outputs 1 and 2 should differ (tx_hash not propagated?)"
+        );
+        assert_ne!(
+            rng_values[0], rng_values[2],
+            "RNG outputs 0 and 2 should differ (tx_hash not propagated?)"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Fix `cargo +nightly fmt` formatting in the RNG regression test from PR #172
- Add a lightweight executor-level unit test (`test_rng_precompile_different_per_tx`) that verifies the RNG precompile produces distinct output per transaction, without spinning up anvil

## Test plan
- [x] `cargo +nightly fmt --all --check` passes
- [x] `cargo test --package foundry-evm test_rng_precompile_different_per_tx` passes
- [x] Test confirmed to fail when `tx_hash` is `B256::ZERO`