### PR TITLE
docs: add comments for tx_hash RNG precompile propagation

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -502,6 +502,8 @@ where
         },
         block: env.evm_env.block_env.clone(),
         cfg: env.evm_env.cfg_env.clone(),
+        // Propagate tx_hash so the RNG precompile produces random (non-zero) output.
+        // See: https://github.com/SeismicSystems/seismic-revm/issues/199
         tx: SeismicTransaction::new(env.tx.base.clone()).with_tx_hash(env.tx.tx_hash),
         chain: SeismicChain::default(),
         local: LocalContext::default(),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1334,6 +1334,7 @@ impl Backend {
     > {
         let mut env = self.next_env();
         env.tx = tx.pending_transaction.to_revm_tx_env();
+        // Set tx_hash so the RNG precompile produces random (non-zero) output.
         env.tx.tx_hash = *tx.pending_transaction.hash();
 
         /*
@@ -3040,6 +3041,7 @@ impl Backend {
         let target_tx = block.transactions[index].clone();
         let target_tx = PendingTransaction::from_maybe_impersonated(target_tx)?;
         let mut tx_env = target_tx.to_revm_tx_env();
+        // Set tx_hash so the RNG precompile produces random (non-zero) output.
         tx_env.tx_hash = *target_tx.hash();
 
         let config = tracer_config.into_json();


### PR DESCRIPTION
## Summary
- Add comments explaining why `tx_hash` must be propagated into the EVM context so the RNG precompile produces random (non-zero) output
- Links to https://github.com/SeismicSystems/seismic-revm/issues/199

## Test plan
- No logic changes, comments only