### PR TITLE
feat(config): add shielded literal warning IDs + bump seismic-compilers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=e6e099e7314068a4290475fdad1d661a5bcac6bc#e6e099e7314068a4290475fdad1d661a5bcac6bc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4691,7 +4691,7 @@ dependencies = [
  "foundry-compilers-core",
  "fs_extra",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "path-slash",
  "rand 0.9.2",
  "rayon",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=e6e099e7314068a4290475fdad1d661a5bcac6bc#e6e099e7314068a4290475fdad1d661a5bcac6bc"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -4722,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=e6e099e7314068a4290475fdad1d661a5bcac6bc#e6e099e7314068a4290475fdad1d661a5bcac6bc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4744,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=e6e099e7314068a4290475fdad1d661a5bcac6bc#e6e099e7314068a4290475fdad1d661a5bcac6bc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=072eff160d978e5e4248af8d56cb2c7d95b40ba9#072eff160d978e5e4248af8d56cb2c7d95b40ba9"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=e6e099e7314068a4290475fdad1d661a5bcac6bc#e6e099e7314068a4290475fdad1d661a5bcac6bc"
 dependencies = [
  "alloy-primitives",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,10 +412,10 @@ alloy-op-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev 
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "039d51496b9b9a0cb4fea6d606e472211b462073" }
 
 # foundry
-foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
-foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
-foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "072eff160d978e5e4248af8d56cb2c7d95b40ba9" }
+foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
+foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
+foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
 
 foundry-fork-db = { git = "https://github.com/SeismicSystems/seismic-foundry-fork-db.git", rev = "e5fb1f8838b517dbaaccc08a8af6767fe2e70c4e" }

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -140,6 +140,28 @@ pub enum SolidityErrorCode {
     TransientStorageUsed,
     /// There are more than 256 warnings. Ignoring the rest.
     TooManyWarnings,
+    /// Warning: constructor has shielded parameter types (CREATE doesn't encrypt calldata)
+    ShieldedConstructorParam,
+    /// Warning: shielded literal in `new(...)` expression args (int)
+    ShieldedLiteralNewExprInt,
+    /// Warning: shielded literal in `new(...)` expression args (bool)
+    ShieldedLiteralNewExprBool,
+    /// Warning: shielded literal in `new(...)` expression args (address)
+    ShieldedLiteralNewExprAddress,
+    /// Warning: shielded literal in `new(...)` expression args (fixedbytes)
+    ShieldedLiteralNewExprFixedbytes,
+    /// Warning: shielded literal in `new(...)` expression args (enum)
+    ShieldedLiteralNewExprEnum,
+    /// Warning: shielded literal in external call args (int)
+    ShieldedLiteralExtCallInt,
+    /// Warning: shielded literal in external call args (bool)
+    ShieldedLiteralExtCallBool,
+    /// Warning: shielded literal in external call args (address)
+    ShieldedLiteralExtCallAddress,
+    /// Warning: shielded literal in external call args (fixedbytes)
+    ShieldedLiteralExtCallFixedbytes,
+    /// Warning: shielded literal in external call args (enum)
+    ShieldedLiteralExtCallEnum,
     /// All other error codes
     Other(u64),
 }
@@ -167,6 +189,17 @@ impl SolidityErrorCode {
             Self::PragmaSolidity => "pragma-solidity",
             Self::TransientStorageUsed => "transient-storage",
             Self::TooManyWarnings => "too-many-warnings",
+            Self::ShieldedConstructorParam => "shielded-constructor-param",
+            Self::ShieldedLiteralNewExprInt => "shielded-literal-new-int",
+            Self::ShieldedLiteralNewExprBool => "shielded-literal-new-bool",
+            Self::ShieldedLiteralNewExprAddress => "shielded-literal-new-address",
+            Self::ShieldedLiteralNewExprFixedbytes => "shielded-literal-new-fixedbytes",
+            Self::ShieldedLiteralNewExprEnum => "shielded-literal-new-enum",
+            Self::ShieldedLiteralExtCallInt => "shielded-literal-ext-call-int",
+            Self::ShieldedLiteralExtCallBool => "shielded-literal-ext-call-bool",
+            Self::ShieldedLiteralExtCallAddress => "shielded-literal-ext-call-address",
+            Self::ShieldedLiteralExtCallFixedbytes => "shielded-literal-ext-call-fixedbytes",
+            Self::ShieldedLiteralExtCallEnum => "shielded-literal-ext-call-enum",
             Self::Other(code) => return Err(*code),
         };
         Ok(s)
@@ -193,6 +226,17 @@ impl From<SolidityErrorCode> for u64 {
             SolidityErrorCode::PragmaSolidity => 3420,
             SolidityErrorCode::TransientStorageUsed => 2394,
             SolidityErrorCode::TooManyWarnings => 4591,
+            SolidityErrorCode::ShieldedConstructorParam => 5500,
+            SolidityErrorCode::ShieldedLiteralNewExprInt => 5501,
+            SolidityErrorCode::ShieldedLiteralNewExprBool => 5502,
+            SolidityErrorCode::ShieldedLiteralNewExprAddress => 5503,
+            SolidityErrorCode::ShieldedLiteralNewExprFixedbytes => 5504,
+            SolidityErrorCode::ShieldedLiteralNewExprEnum => 5505,
+            SolidityErrorCode::ShieldedLiteralExtCallInt => 5506,
+            SolidityErrorCode::ShieldedLiteralExtCallBool => 5507,
+            SolidityErrorCode::ShieldedLiteralExtCallAddress => 5508,
+            SolidityErrorCode::ShieldedLiteralExtCallFixedbytes => 5509,
+            SolidityErrorCode::ShieldedLiteralExtCallEnum => 5510,
             SolidityErrorCode::Other(code) => code,
         }
     }
@@ -229,6 +273,17 @@ impl FromStr for SolidityErrorCode {
             "pragma-solidity" => Self::PragmaSolidity,
             "transient-storage" => Self::TransientStorageUsed,
             "too-many-warnings" => Self::TooManyWarnings,
+            "shielded-constructor-param" => Self::ShieldedConstructorParam,
+            "shielded-literal-new-int" => Self::ShieldedLiteralNewExprInt,
+            "shielded-literal-new-bool" => Self::ShieldedLiteralNewExprBool,
+            "shielded-literal-new-address" => Self::ShieldedLiteralNewExprAddress,
+            "shielded-literal-new-fixedbytes" => Self::ShieldedLiteralNewExprFixedbytes,
+            "shielded-literal-new-enum" => Self::ShieldedLiteralNewExprEnum,
+            "shielded-literal-ext-call-int" => Self::ShieldedLiteralExtCallInt,
+            "shielded-literal-ext-call-bool" => Self::ShieldedLiteralExtCallBool,
+            "shielded-literal-ext-call-address" => Self::ShieldedLiteralExtCallAddress,
+            "shielded-literal-ext-call-fixedbytes" => Self::ShieldedLiteralExtCallFixedbytes,
+            "shielded-literal-ext-call-enum" => Self::ShieldedLiteralExtCallEnum,
             _ => return Err(format!("Unknown variant {s}")),
         };
 
@@ -256,6 +311,17 @@ impl From<u64> for SolidityErrorCode {
             3420 => Self::PragmaSolidity,
             2394 => Self::TransientStorageUsed,
             4591 => Self::TooManyWarnings,
+            5500 => Self::ShieldedConstructorParam,
+            5501 => Self::ShieldedLiteralNewExprInt,
+            5502 => Self::ShieldedLiteralNewExprBool,
+            5503 => Self::ShieldedLiteralNewExprAddress,
+            5504 => Self::ShieldedLiteralNewExprFixedbytes,
+            5505 => Self::ShieldedLiteralNewExprEnum,
+            5506 => Self::ShieldedLiteralExtCallInt,
+            5507 => Self::ShieldedLiteralExtCallBool,
+            5508 => Self::ShieldedLiteralExtCallAddress,
+            5509 => Self::ShieldedLiteralExtCallFixedbytes,
+            5510 => Self::ShieldedLiteralExtCallEnum,
             other => Self::Other(other),
         }
     }
@@ -289,6 +355,97 @@ impl<'de> Deserialize<'de> for SolidityErrorCode {
         match SolCode::deserialize(deserializer)? {
             SolCode::Code(code) => Ok(code.into()),
             SolCode::Name(name) => name.parse().map_err(serde::de::Error::custom),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All shielded warning variants with their numeric IDs and string aliases.
+    const SHIELDED_VARIANTS: &[(SolidityErrorCode, u64, &str)] = &[
+        (SolidityErrorCode::ShieldedConstructorParam, 5500, "shielded-constructor-param"),
+        (SolidityErrorCode::ShieldedLiteralNewExprInt, 5501, "shielded-literal-new-int"),
+        (SolidityErrorCode::ShieldedLiteralNewExprBool, 5502, "shielded-literal-new-bool"),
+        (SolidityErrorCode::ShieldedLiteralNewExprAddress, 5503, "shielded-literal-new-address"),
+        (
+            SolidityErrorCode::ShieldedLiteralNewExprFixedbytes,
+            5504,
+            "shielded-literal-new-fixedbytes",
+        ),
+        (SolidityErrorCode::ShieldedLiteralNewExprEnum, 5505, "shielded-literal-new-enum"),
+        (SolidityErrorCode::ShieldedLiteralExtCallInt, 5506, "shielded-literal-ext-call-int"),
+        (SolidityErrorCode::ShieldedLiteralExtCallBool, 5507, "shielded-literal-ext-call-bool"),
+        (
+            SolidityErrorCode::ShieldedLiteralExtCallAddress,
+            5508,
+            "shielded-literal-ext-call-address",
+        ),
+        (
+            SolidityErrorCode::ShieldedLiteralExtCallFixedbytes,
+            5509,
+            "shielded-literal-ext-call-fixedbytes",
+        ),
+        (SolidityErrorCode::ShieldedLiteralExtCallEnum, 5510, "shielded-literal-ext-call-enum"),
+    ];
+
+    #[test]
+    fn shielded_variant_from_u64() {
+        for &(expected_variant, id, _) in SHIELDED_VARIANTS {
+            let variant: SolidityErrorCode = id.into();
+            assert_eq!(variant, expected_variant, "From<u64> for {id} should yield named variant");
+            // Must NOT be Other(id)
+            assert_ne!(
+                variant,
+                SolidityErrorCode::Other(id),
+                "{id} should not fall through to Other"
+            );
+        }
+    }
+
+    #[test]
+    fn shielded_variant_to_u64() {
+        for &(variant, expected_id, _) in SHIELDED_VARIANTS {
+            let id: u64 = variant.into();
+            assert_eq!(id, expected_id, "u64 from {variant:?} should be {expected_id}");
+        }
+    }
+
+    #[test]
+    fn shielded_variant_u64_roundtrip() {
+        for &(variant, id, _) in SHIELDED_VARIANTS {
+            let converted: u64 = variant.into();
+            let back: SolidityErrorCode = converted.into();
+            assert_eq!(back, variant, "u64 round-trip failed for {id}");
+        }
+    }
+
+    #[test]
+    fn shielded_variant_as_str() {
+        for &(variant, _, expected_str) in SHIELDED_VARIANTS {
+            assert_eq!(
+                variant.as_str().unwrap(),
+                expected_str,
+                "as_str() mismatch for {variant:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn shielded_variant_from_str() {
+        for &(expected_variant, _, alias) in SHIELDED_VARIANTS {
+            let parsed: SolidityErrorCode = alias.parse().unwrap();
+            assert_eq!(parsed, expected_variant, "FromStr mismatch for {alias:?}");
+        }
+    }
+
+    #[test]
+    fn shielded_variant_str_roundtrip() {
+        for &(variant, _, _) in SHIELDED_VARIANTS {
+            let s = variant.as_str().unwrap();
+            let back: SolidityErrorCode = s.parse().unwrap();
+            assert_eq!(back, variant, "str round-trip failed for {s}");
         }
     }
 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1302,6 +1302,249 @@ Compiler run successful!
 "#]]);
 });
 
+// test that ssolc shielded literal warnings (5500–5510) are emitted in src/ and can be suppressed
+forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
+    // Skip if ssolc is not installed
+    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
+        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+        return;
+    }
+
+    // Enable seismic (ssolc) and suppress unrelated warnings
+    prj.update_config(|config| {
+        config.seismic = true;
+        config.ignored_error_codes = vec![
+            SolidityErrorCode::SpdxLicenseNotProvided,
+        ];
+    });
+
+    // Receiver lives in src/ — always compiled, provides the shielded interface
+    prj.add_raw_source(
+        "src/Receiver.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Receiver {
+    suint256 internal val;
+    constructor(suint256 _v) { val = _v; }
+    function setVal(suint256 _v) external { val = _v; }
+}
+"#,
+    );
+
+    // Caller in src/ — all warnings should fire
+    prj.add_raw_source(
+        "src/Caller.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Receiver} from "./Receiver.sol";
+
+contract Caller {
+    Receiver public r;
+    constructor() {
+        // triggers 5501 (shielded-literal-new-int)
+        r = new Receiver(suint256(42));
+    }
+    function callWithLiteral() external {
+        // triggers 5506 (shielded-literal-ext-call-int)
+        r.setVal(suint256(100));
+    }
+}
+"#,
+    );
+
+    // Build: expect all shielded literal warnings from src/
+    let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Warning (5500)"),
+        "expected warning 5500 (shielded-constructor-param) in src/ output:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Warning (5501)"),
+        "expected warning 5501 (shielded-literal-new-int) in src/ output:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Warning (5506)"),
+        "expected warning 5506 (shielded-literal-ext-call-int) in src/ output:\n{stdout}"
+    );
+
+    // Now suppress all shielded warnings and the pre-release warning, then rebuild
+    prj.update_config(|config| {
+        config.seismic = true;
+        config.ignored_error_codes = vec![
+            SolidityErrorCode::SpdxLicenseNotProvided,
+            SolidityErrorCode::ShieldedConstructorParam,
+            SolidityErrorCode::ShieldedLiteralNewExprInt,
+            SolidityErrorCode::ShieldedLiteralExtCallInt,
+            // 3805 = pre-release compiler warning
+            SolidityErrorCode::Other(3805),
+        ];
+    });
+
+    // With all warnings suppressed, build should report no warnings
+    let output2 = cmd.forge_fuse().args(["build", "--force"]).assert_success().get_output().clone();
+    let stdout2 = String::from_utf8_lossy(&output2.stdout);
+    assert!(
+        stdout2.contains("Compiler run successful!") && !stdout2.contains("with warnings"),
+        "expected clean build with all warnings suppressed, got:\n{stdout2}"
+    );
+});
+
+// test that seismic-compilers suppresses ext-call shielded warnings in test/ files
+// but still emits constructor/new-expr warnings (CREATE always leaks, even in tests)
+forgetest!(shielded_literal_warnings_suppressed_in_test, |prj, cmd| {
+    // Skip if ssolc is not installed
+    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
+        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+        return;
+    }
+
+    prj.update_config(|config| {
+        config.seismic = true;
+        config.ignored_error_codes = vec![
+            SolidityErrorCode::SpdxLicenseNotProvided,
+            // suppress pre-release warning so it doesn't interfere
+            SolidityErrorCode::Other(3805),
+        ];
+    });
+
+    // Receiver in src/
+    prj.add_raw_source(
+        "src/Receiver.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Receiver {
+    suint256 internal val;
+    constructor(suint256 _v) { val = _v; }
+    function setVal(suint256 _v) external { val = _v; }
+}
+"#,
+    );
+
+    // Same patterns but in test/ — ext-call warnings (5506) should be auto-suppressed
+    // by seismic-compilers, but constructor (5500) and new-expr (5501) should remain
+    prj.add_raw_source(
+        "test/Caller.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Receiver} from "../src/Receiver.sol";
+
+contract CallerTest {
+    Receiver public r;
+    constructor() {
+        // 5501 (new-expr) — NOT suppressed, CREATE always leaks
+        r = new Receiver(suint256(42));
+    }
+    function testCallWithLiteral() external {
+        // 5506 (ext-call) — suppressed in test files
+        r.setVal(suint256(100));
+    }
+}
+"#,
+    );
+
+    let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // 5500 (constructor param) and 5501 (new-expr) should still appear
+    assert!(
+        stdout.contains("Warning (5500)"),
+        "expected warning 5500 (shielded-constructor-param) even in test/ file:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Warning (5501)"),
+        "expected warning 5501 (shielded-literal-new-int) even in test/ file:\n{stdout}"
+    );
+
+    // 5506 (ext-call) should be suppressed by seismic-compilers in test/ files
+    assert!(
+        !stdout.contains("Warning (5506)"),
+        "warning 5506 (shielded-literal-ext-call-int) should be suppressed in test/ file:\n{stdout}"
+    );
+});
+
+// test that seismic-compilers suppresses ext-call shielded warnings in script/ files
+forgetest!(shielded_literal_warnings_suppressed_in_script, |prj, cmd| {
+    // Skip if ssolc is not installed
+    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
+        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+        return;
+    }
+
+    prj.update_config(|config| {
+        config.seismic = true;
+        config.ignored_error_codes = vec![
+            SolidityErrorCode::SpdxLicenseNotProvided,
+            SolidityErrorCode::Other(3805),
+        ];
+    });
+
+    // Receiver in src/
+    prj.add_raw_source(
+        "src/Receiver.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Receiver {
+    suint256 internal val;
+    constructor(suint256 _v) { val = _v; }
+    function setVal(suint256 _v) external { val = _v; }
+}
+"#,
+    );
+
+    // Same patterns in script/ — ext-call warnings should be suppressed
+    prj.add_raw_source(
+        "script/Deploy.s.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Receiver} from "../src/Receiver.sol";
+
+contract DeployScript {
+    Receiver public r;
+    constructor() {
+        // 5501 (new-expr) — NOT suppressed
+        r = new Receiver(suint256(42));
+    }
+    function run() external {
+        // 5506 (ext-call) — suppressed in script files
+        r.setVal(suint256(100));
+    }
+}
+"#,
+    );
+
+    let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // 5500 and 5501 should still appear
+    assert!(
+        stdout.contains("Warning (5500)"),
+        "expected warning 5500 (shielded-constructor-param) even in script/ file:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Warning (5501)"),
+        "expected warning 5501 (shielded-literal-new-int) even in script/ file:\n{stdout}"
+    );
+
+    // 5506 should be suppressed
+    assert!(
+        !stdout.contains("Warning (5506)"),
+        "warning 5506 (shielded-literal-ext-call-int) should be suppressed in script/ file:\n{stdout}"
+    );
+});
+
 // test that a failing `forge build` does not impact followup builds
 forgetest!(can_build_after_failure, |prj, cmd| {
     prj.insert_ds_test();

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1313,9 +1313,7 @@ forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
     // Enable seismic (ssolc) and suppress unrelated warnings
     prj.update_config(|config| {
         config.seismic = true;
-        config.ignored_error_codes = vec![
-            SolidityErrorCode::SpdxLicenseNotProvided,
-        ];
+        config.ignored_error_codes = vec![SolidityErrorCode::SpdxLicenseNotProvided];
     });
 
     // Receiver lives in src/ — always compiled, provides the shielded interface
@@ -1481,10 +1479,8 @@ forgetest!(shielded_literal_warnings_suppressed_in_script, |prj, cmd| {
 
     prj.update_config(|config| {
         config.seismic = true;
-        config.ignored_error_codes = vec![
-            SolidityErrorCode::SpdxLicenseNotProvided,
-            SolidityErrorCode::Other(3805),
-        ];
+        config.ignored_error_codes =
+            vec![SolidityErrorCode::SpdxLicenseNotProvided, SolidityErrorCode::Other(3805)];
     });
 
     // Receiver in src/

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -129,6 +129,10 @@ impl ScriptTransactionBuilder {
         let constructor_args = &creation_code[bytecode.len()..];
 
         let Some(constructor) = info.abi.constructor() else { return Ok(()) };
+
+        // TODO: also encrypt calldata for CREATE (i.e., support seismic transactions for
+        // CREATE once we support it across all of our repos)
+
         let values = constructor.abi_decode_input(constructor_args).inspect_err(|_| {
                 error!(
                     contract=?self.transaction.contract_name,


### PR DESCRIPTION
## Summary

- Add 11 `SolidityErrorCode` variants (5500–5510) for ssolc shielded literal warnings so they are recognized by name instead of falling through to `Other(u64)`. Covers all 4 match arms: `as_str()`, `From<u64>`, `FromStr`, `Into<u64>`.
- Bump `seismic-compilers` to `e6e099e` ([PR #19](https://github.com/SeismicSystems/seismic-compilers/pull/19)) which adds named constants for these warning IDs and context-aware suppression in test/script files.
- Add unit tests for round-trip conversion of all 11 variants.
- Add 3 CLI integration tests (require `ssolc`) verifying end-to-end behavior:
  - `src/` files: all warnings (5500, 5501, 5506) emitted; suppressible via `ignored_error_codes`
  - `test/` files: ext-call warnings (5506) auto-suppressed by seismic-compilers; constructor (5500) and new-expr (5501) still emitted
  - `script/` files: same suppression as test/

## Test plan

- [x] `cargo test -p foundry-config -- error::tests` — unit tests for variant round-trips
- [x] `cargo test -p forge --test cli shielded_literal_warnings` — CLI integration tests (requires `ssolc`)
- [x] `cargo check -p foundry-config` — clean compilation