### PR TITLE
feat(config): improve ssolc path resolution, args, and DX

### DIFF
--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -140,29 +140,9 @@ pub enum SolidityErrorCode {
     TransientStorageUsed,
     /// There are more than 256 warnings. Ignoring the rest.
     TooManyWarnings,
-    /// Warning: constructor has shielded parameter types (CREATE doesn't encrypt calldata)
-    ShieldedConstructorParam,
-    /// Warning: shielded literal in `new(...)` expression args (int)
-    ShieldedLiteralNewExprInt,
-    /// Warning: shielded literal in `new(...)` expression args (bool)
-    ShieldedLiteralNewExprBool,
-    /// Warning: shielded literal in `new(...)` expression args (address)
-    ShieldedLiteralNewExprAddress,
-    /// Warning: shielded literal in `new(...)` expression args (fixedbytes)
-    ShieldedLiteralNewExprFixedbytes,
-    /// Warning: shielded literal in `new(...)` expression args (enum)
-    ShieldedLiteralNewExprEnum,
-    /// Warning: shielded literal in external call args (int)
-    ShieldedLiteralExtCallInt,
-    /// Warning: shielded literal in external call args (bool)
-    ShieldedLiteralExtCallBool,
-    /// Warning: shielded literal in external call args (address)
-    ShieldedLiteralExtCallAddress,
-    /// Warning: shielded literal in external call args (fixedbytes)
-    ShieldedLiteralExtCallFixedbytes,
-    /// Warning: shielded literal in external call args (enum)
-    ShieldedLiteralExtCallEnum,
     /// All other error codes
+    /// Note: Seismic/ssolc warning codes (>= 10000) are handled via `Other(code)` and
+    /// suppressed by a threshold check in seismic-compilers, not by named variants here.
     Other(u64),
 }
 
@@ -189,17 +169,6 @@ impl SolidityErrorCode {
             Self::PragmaSolidity => "pragma-solidity",
             Self::TransientStorageUsed => "transient-storage",
             Self::TooManyWarnings => "too-many-warnings",
-            Self::ShieldedConstructorParam => "shielded-constructor-param",
-            Self::ShieldedLiteralNewExprInt => "shielded-literal-new-int",
-            Self::ShieldedLiteralNewExprBool => "shielded-literal-new-bool",
-            Self::ShieldedLiteralNewExprAddress => "shielded-literal-new-address",
-            Self::ShieldedLiteralNewExprFixedbytes => "shielded-literal-new-fixedbytes",
-            Self::ShieldedLiteralNewExprEnum => "shielded-literal-new-enum",
-            Self::ShieldedLiteralExtCallInt => "shielded-literal-ext-call-int",
-            Self::ShieldedLiteralExtCallBool => "shielded-literal-ext-call-bool",
-            Self::ShieldedLiteralExtCallAddress => "shielded-literal-ext-call-address",
-            Self::ShieldedLiteralExtCallFixedbytes => "shielded-literal-ext-call-fixedbytes",
-            Self::ShieldedLiteralExtCallEnum => "shielded-literal-ext-call-enum",
             Self::Other(code) => return Err(*code),
         };
         Ok(s)
@@ -226,17 +195,6 @@ impl From<SolidityErrorCode> for u64 {
             SolidityErrorCode::PragmaSolidity => 3420,
             SolidityErrorCode::TransientStorageUsed => 2394,
             SolidityErrorCode::TooManyWarnings => 4591,
-            SolidityErrorCode::ShieldedConstructorParam => 5500,
-            SolidityErrorCode::ShieldedLiteralNewExprInt => 5501,
-            SolidityErrorCode::ShieldedLiteralNewExprBool => 5502,
-            SolidityErrorCode::ShieldedLiteralNewExprAddress => 5503,
-            SolidityErrorCode::ShieldedLiteralNewExprFixedbytes => 5504,
-            SolidityErrorCode::ShieldedLiteralNewExprEnum => 5505,
-            SolidityErrorCode::ShieldedLiteralExtCallInt => 5506,
-            SolidityErrorCode::ShieldedLiteralExtCallBool => 5507,
-            SolidityErrorCode::ShieldedLiteralExtCallAddress => 5508,
-            SolidityErrorCode::ShieldedLiteralExtCallFixedbytes => 5509,
-            SolidityErrorCode::ShieldedLiteralExtCallEnum => 5510,
             SolidityErrorCode::Other(code) => code,
         }
     }
@@ -273,17 +231,6 @@ impl FromStr for SolidityErrorCode {
             "pragma-solidity" => Self::PragmaSolidity,
             "transient-storage" => Self::TransientStorageUsed,
             "too-many-warnings" => Self::TooManyWarnings,
-            "shielded-constructor-param" => Self::ShieldedConstructorParam,
-            "shielded-literal-new-int" => Self::ShieldedLiteralNewExprInt,
-            "shielded-literal-new-bool" => Self::ShieldedLiteralNewExprBool,
-            "shielded-literal-new-address" => Self::ShieldedLiteralNewExprAddress,
-            "shielded-literal-new-fixedbytes" => Self::ShieldedLiteralNewExprFixedbytes,
-            "shielded-literal-new-enum" => Self::ShieldedLiteralNewExprEnum,
-            "shielded-literal-ext-call-int" => Self::ShieldedLiteralExtCallInt,
-            "shielded-literal-ext-call-bool" => Self::ShieldedLiteralExtCallBool,
-            "shielded-literal-ext-call-address" => Self::ShieldedLiteralExtCallAddress,
-            "shielded-literal-ext-call-fixedbytes" => Self::ShieldedLiteralExtCallFixedbytes,
-            "shielded-literal-ext-call-enum" => Self::ShieldedLiteralExtCallEnum,
             _ => return Err(format!("Unknown variant {s}")),
         };
 
@@ -311,17 +258,6 @@ impl From<u64> for SolidityErrorCode {
             3420 => Self::PragmaSolidity,
             2394 => Self::TransientStorageUsed,
             4591 => Self::TooManyWarnings,
-            5500 => Self::ShieldedConstructorParam,
-            5501 => Self::ShieldedLiteralNewExprInt,
-            5502 => Self::ShieldedLiteralNewExprBool,
-            5503 => Self::ShieldedLiteralNewExprAddress,
-            5504 => Self::ShieldedLiteralNewExprFixedbytes,
-            5505 => Self::ShieldedLiteralNewExprEnum,
-            5506 => Self::ShieldedLiteralExtCallInt,
-            5507 => Self::ShieldedLiteralExtCallBool,
-            5508 => Self::ShieldedLiteralExtCallAddress,
-            5509 => Self::ShieldedLiteralExtCallFixedbytes,
-            5510 => Self::ShieldedLiteralExtCallEnum,
             other => Self::Other(other),
         }
     }
@@ -359,93 +295,3 @@ impl<'de> Deserialize<'de> for SolidityErrorCode {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// All shielded warning variants with their numeric IDs and string aliases.
-    const SHIELDED_VARIANTS: &[(SolidityErrorCode, u64, &str)] = &[
-        (SolidityErrorCode::ShieldedConstructorParam, 5500, "shielded-constructor-param"),
-        (SolidityErrorCode::ShieldedLiteralNewExprInt, 5501, "shielded-literal-new-int"),
-        (SolidityErrorCode::ShieldedLiteralNewExprBool, 5502, "shielded-literal-new-bool"),
-        (SolidityErrorCode::ShieldedLiteralNewExprAddress, 5503, "shielded-literal-new-address"),
-        (
-            SolidityErrorCode::ShieldedLiteralNewExprFixedbytes,
-            5504,
-            "shielded-literal-new-fixedbytes",
-        ),
-        (SolidityErrorCode::ShieldedLiteralNewExprEnum, 5505, "shielded-literal-new-enum"),
-        (SolidityErrorCode::ShieldedLiteralExtCallInt, 5506, "shielded-literal-ext-call-int"),
-        (SolidityErrorCode::ShieldedLiteralExtCallBool, 5507, "shielded-literal-ext-call-bool"),
-        (
-            SolidityErrorCode::ShieldedLiteralExtCallAddress,
-            5508,
-            "shielded-literal-ext-call-address",
-        ),
-        (
-            SolidityErrorCode::ShieldedLiteralExtCallFixedbytes,
-            5509,
-            "shielded-literal-ext-call-fixedbytes",
-        ),
-        (SolidityErrorCode::ShieldedLiteralExtCallEnum, 5510, "shielded-literal-ext-call-enum"),
-    ];
-
-    #[test]
-    fn shielded_variant_from_u64() {
-        for &(expected_variant, id, _) in SHIELDED_VARIANTS {
-            let variant: SolidityErrorCode = id.into();
-            assert_eq!(variant, expected_variant, "From<u64> for {id} should yield named variant");
-            // Must NOT be Other(id)
-            assert_ne!(
-                variant,
-                SolidityErrorCode::Other(id),
-                "{id} should not fall through to Other"
-            );
-        }
-    }
-
-    #[test]
-    fn shielded_variant_to_u64() {
-        for &(variant, expected_id, _) in SHIELDED_VARIANTS {
-            let id: u64 = variant.into();
-            assert_eq!(id, expected_id, "u64 from {variant:?} should be {expected_id}");
-        }
-    }
-
-    #[test]
-    fn shielded_variant_u64_roundtrip() {
-        for &(variant, id, _) in SHIELDED_VARIANTS {
-            let converted: u64 = variant.into();
-            let back: SolidityErrorCode = converted.into();
-            assert_eq!(back, variant, "u64 round-trip failed for {id}");
-        }
-    }
-
-    #[test]
-    fn shielded_variant_as_str() {
-        for &(variant, _, expected_str) in SHIELDED_VARIANTS {
-            assert_eq!(
-                variant.as_str().unwrap(),
-                expected_str,
-                "as_str() mismatch for {variant:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn shielded_variant_from_str() {
-        for &(expected_variant, _, alias) in SHIELDED_VARIANTS {
-            let parsed: SolidityErrorCode = alias.parse().unwrap();
-            assert_eq!(parsed, expected_variant, "FromStr mismatch for {alias:?}");
-        }
-    }
-
-    #[test]
-    fn shielded_variant_str_roundtrip() {
-        for &(variant, _, _) in SHIELDED_VARIANTS {
-            let s = variant.as_str().unwrap();
-            let back: SolidityErrorCode = s.parse().unwrap();
-            assert_eq!(back, variant, "str round-trip failed for {s}");
-        }
-    }
-}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -548,6 +548,12 @@ pub struct Config {
     /// because it looks like it might also be used to configure execution (tests, anvil, etc).
     pub seismic: bool,
 
+    /// When true and `seismic` is enabled, passes `--no-seismic-warnings` to ssolc.
+    ///
+    /// Defaults to `true` so shielded-literal warnings are suppressed globally.
+    /// Set `no_seismic_warnings = false` in foundry.toml to re-enable them.
+    pub no_seismic_warnings: bool,
+
     /// Warnings gathered when loading the Config. See [`WarningsProvider`] for more information.
     #[serde(rename = "__warnings", default, skip_serializing)]
     pub warnings: Vec<Warning>,
@@ -947,6 +953,12 @@ impl Config {
                 );
             }
 
+            // Pass --no-seismic-warnings to ssolc unless the user opted out.
+            if self.no_seismic_warnings
+                && !self.extra_args.contains(&"--no-seismic-warnings".to_string())
+            {
+                self.extra_args.push("--no-seismic-warnings".to_string());
+            }
         }
     }
 
@@ -1175,7 +1187,8 @@ impl Config {
             if let Some(ref solc_req) = self.solc {
                 match solc_req {
                     SolcReq::Version(_) => {
-                        // Ignore the version request — use ssolc from PATH
+                        // TODO: support using different ssolc versions
+                        // For now, ignore the version request — use ssolc from PATH
                         let ssolc_path = self.get_default_ssolc_path()?;
                         return Ok(Some(Solc::new(ssolc_path)?));
                     }
@@ -2535,6 +2548,7 @@ impl Default for Config {
             additional_compiler_profiles: Default::default(),
             compilation_restrictions: Default::default(),
             seismic: true,
+            no_seismic_warnings: true,
             script_execution_protection: true,
             _non_exhaustive: (),
         }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -548,11 +548,13 @@ pub struct Config {
     /// because it looks like it might also be used to configure execution (tests, anvil, etc).
     pub seismic: bool,
 
-    /// When true and `seismic` is enabled, passes `--no-seismic-warnings` to ssolc.
-    ///
-    /// Defaults to `true` so shielded-literal warnings are suppressed globally.
-    /// Set `no_seismic_warnings = false` in foundry.toml to re-enable them.
+    /// When true and `seismic` is enabled, passes `--no-seismic-warnings` to ssolc,
+    /// suppressing all seismic warnings globally (src, test, and script files).
     pub no_seismic_warnings: bool,
+
+    /// When true, show seismic warnings in test files (`.t.sol`).
+    /// By default (`false`), seismic warnings are suppressed in test files.
+    pub seismic_warnings_test: bool,
 
     /// Warnings gathered when loading the Config. See [`WarningsProvider`] for more information.
     #[serde(rename = "__warnings", default, skip_serializing)]
@@ -953,12 +955,8 @@ impl Config {
                 );
             }
 
-            // Pass --no-seismic-warnings to ssolc unless the user opted out.
-            if self.no_seismic_warnings
-                && !self.extra_args.contains(&"--no-seismic-warnings".to_string())
-            {
-                self.extra_args.push("--no-seismic-warnings".to_string());
-            }
+            // no_seismic_warnings is handled via CliSettings.no_seismic_warnings,
+            // which filters warnings post-compilation in seismic-compilers.
         }
     }
 
@@ -1679,8 +1677,12 @@ impl Config {
             settings = settings.with_ast();
         }
 
-        let cli_settings =
-            CliSettings { extra_args: self.extra_args.clone(), ..Default::default() };
+        let cli_settings = CliSettings {
+            extra_args: self.extra_args.clone(),
+            seismic_warnings_in_tests: self.seismic_warnings_test,
+            no_seismic_warnings: self.no_seismic_warnings,
+            ..Default::default()
+        };
 
         Ok(SolcSettings { settings, cli_settings })
     }
@@ -2548,7 +2550,8 @@ impl Default for Config {
             additional_compiler_profiles: Default::default(),
             compilation_restrictions: Default::default(),
             seismic: true,
-            no_seismic_warnings: true,
+            no_seismic_warnings: false,
+            seismic_warnings_test: false,
             script_execution_protection: true,
             _non_exhaustive: (),
         }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -932,6 +932,22 @@ impl Config {
         if self.evm_version == EvmVersion::Mercury {
             self.seismic = true;
         }
+
+        if self.seismic {
+            // ssolc requires --unsafe-via-ir alongside via_ir.
+            if self.via_ir && !self.unsafe_via_ir {
+                eprintln!(
+                    "{}",
+                    yansi::Paint::yellow(
+                        "Warning: `via_ir = true` requires `unsafe_via_ir = true` in foundry.toml \
+                         (or --unsafe-via-ir on the CLI) when using ssolc. \
+                         The IR pipeline has incomplete shielded-type support and may produce \
+                         incorrect results."
+                    )
+                );
+            }
+
+        }
     }
 
     /// Cleans up any duplicate `Remapping` and sorts them

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -38,6 +38,7 @@ use foundry_compilers::{
     error::SolcError,
     multi::{MultiCompilerParser, MultiCompilerRestrictions},
     solc::{CliSettings, SolcSettings},
+    SeismicConfig,
 };
 use regex::Regex;
 // use revm::primitives::hardfork::SpecId;
@@ -955,7 +956,7 @@ impl Config {
                 );
             }
 
-            // no_seismic_warnings is handled via CliSettings.no_seismic_warnings,
+            // no_seismic_warnings is handled via CliSettings.seismic_cfg,
             // which filters warnings post-compilation in seismic-compilers.
         }
     }
@@ -1679,8 +1680,10 @@ impl Config {
 
         let cli_settings = CliSettings {
             extra_args: self.extra_args.clone(),
-            seismic_warnings_in_tests: self.seismic_warnings_test,
-            no_seismic_warnings: self.no_seismic_warnings,
+            seismic_cfg: SeismicConfig {
+                seismic_warnings_in_tests: self.seismic_warnings_test,
+                no_seismic_warnings: self.no_seismic_warnings,
+            },
             ..Default::default()
         };
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1127,21 +1127,25 @@ impl Config {
         Ok(())
     }
 
-    /// Get default ssolc path
+    /// Resolve path to `ssolc` binary by searching the system PATH.
     #[inline]
     pub fn get_default_ssolc_path(&self) -> Result<PathBuf, SolcError> {
-        let default_solc_path = if cfg!(windows) {
-            PathBuf::from("C:\\Program Files\\Seismic\\bin\\ssolc.exe")
-        } else {
-            PathBuf::from("/usr/local/bin/ssolc")
-        };
-        if !default_solc_path.is_file() {
-            return Err(SolcError::msg(format!(
-                "`ssolc` {} does not exist.\nInstructions to install:\nhttps://docs.seismic.systems/getting-started/publish-your-docs#install-the-local-development-suite",
-                default_solc_path.display()
-            )));
-        }
-        Ok(default_solc_path)
+        // Use bare "ssolc" — Solc::new() invokes `ssolc --version` via Command::new(),
+        // which resolves the binary from PATH automatically.
+        let path = PathBuf::from("ssolc");
+        // Quick check that ssolc is actually available before proceeding.
+        std::process::Command::new(&path)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map_err(|_| {
+                SolcError::msg(
+                    "`ssolc` not found in PATH.\n\
+                     Install via: https://docs.seismic.systems/getting-started/installation",
+                )
+            })?;
+        Ok(path)
     }
 
     /// Ensures that the configured version is installed if explicitly set
@@ -1155,10 +1159,9 @@ impl Config {
             if let Some(ref solc_req) = self.solc {
                 match solc_req {
                     SolcReq::Version(_) => {
-                        // Only allow the version they have downloaded
-                        // TODO: support using different versions
-                        let default_solc_path = self.get_default_ssolc_path()?;
-                        return Ok(Some(Solc::new(default_solc_path)?));
+                        // Ignore the version request — use ssolc from PATH
+                        let ssolc_path = self.get_default_ssolc_path()?;
+                        return Ok(Some(Solc::new(ssolc_path)?));
                     }
                     SolcReq::Local(local_solc_path) => {
                         if !local_solc_path.is_file() {
@@ -1171,6 +1174,9 @@ impl Config {
                     }
                 }
             }
+            // No solc explicitly configured — find ssolc in PATH
+            let ssolc_path = self.get_default_ssolc_path()?;
+            return Ok(Some(Solc::new(ssolc_path)?));
         }
 
         if let Some(solc) = &self.solc {

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1302,7 +1302,7 @@ Compiler run successful!
 "#]]);
 });
 
-// test that ssolc shielded literal warnings (5500–5510) are emitted in src/ and can be suppressed
+// test that ssolc shielded literal warnings (>= 10000) are emitted in src/ and can be suppressed
 forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
     // Skip if ssolc is not installed
     if std::process::Command::new("ssolc").arg("--version").output().is_err() {
@@ -1310,11 +1310,9 @@ forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
         return;
     }
 
-    // Enable seismic (ssolc), disable --no-seismic-warnings so warnings are visible,
-    // and suppress unrelated warnings
+    // Enable seismic (ssolc) and suppress unrelated warnings
     prj.update_config(|config| {
         config.seismic = true;
-        config.no_seismic_warnings = false;
         config.ignored_error_codes = vec![SolidityErrorCode::SpdxLicenseNotProvided];
     });
 
@@ -1345,11 +1343,11 @@ import {Receiver} from "./Receiver.sol";
 contract Caller {
     Receiver public r;
     constructor() {
-        // triggers 5501 (shielded-literal-new-int)
+        // triggers 10401 (shielded-literal-new-int)
         r = new Receiver(suint256(42));
     }
     function callWithLiteral() external {
-        // triggers 5506 (shielded-literal-ext-call-int)
+        // triggers 10402 (shielded-literal-ext-call-int)
         r.setVal(suint256(100));
     }
 }
@@ -1360,27 +1358,27 @@ contract Caller {
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("Warning (5500)"),
-        "expected warning 5500 (shielded-constructor-param) in src/ output:\n{stdout}"
+        stdout.contains("Warning (10103)"),
+        "expected warning 10103 (shielded-constructor-param) in src/ output:\n{stdout}"
     );
     assert!(
-        stdout.contains("Warning (5501)"),
-        "expected warning 5501 (shielded-literal-new-int) in src/ output:\n{stdout}"
+        stdout.contains("Warning (10401)"),
+        "expected warning 10401 (shielded-literal-new-int) in src/ output:\n{stdout}"
     );
     assert!(
-        stdout.contains("Warning (5506)"),
-        "expected warning 5506 (shielded-literal-ext-call-int) in src/ output:\n{stdout}"
+        stdout.contains("Warning (10402)"),
+        "expected warning 10402 (shielded-literal-ext-call-int) in src/ output:\n{stdout}"
     );
 
     // Now suppress all shielded warnings and the pre-release warning, then rebuild
     prj.update_config(|config| {
         config.seismic = true;
-        config.no_seismic_warnings = false;
         config.ignored_error_codes = vec![
             SolidityErrorCode::SpdxLicenseNotProvided,
-            SolidityErrorCode::ShieldedConstructorParam,
-            SolidityErrorCode::ShieldedLiteralNewExprInt,
-            SolidityErrorCode::ShieldedLiteralExtCallInt,
+            // seismic warning codes (>= 10000) — use Other(code)
+            SolidityErrorCode::Other(10103), // shielded constructor param
+            SolidityErrorCode::Other(10401), // shielded literal new-expr int
+            SolidityErrorCode::Other(10402), // shielded literal ext-call int
             // 3805 = pre-release compiler warning
             SolidityErrorCode::Other(3805),
         ];
@@ -1395,8 +1393,7 @@ contract Caller {
     );
 });
 
-// test that seismic-compilers suppresses ext-call shielded warnings in test/ files
-// but still emits constructor/new-expr warnings (CREATE always leaks, even in tests)
+// test that all seismic warnings are suppressed in test/ files by default
 forgetest!(shielded_literal_warnings_suppressed_in_test, |prj, cmd| {
     // Skip if ssolc is not installed
     if std::process::Command::new("ssolc").arg("--version").output().is_err() {
@@ -1406,7 +1403,6 @@ forgetest!(shielded_literal_warnings_suppressed_in_test, |prj, cmd| {
 
     prj.update_config(|config| {
         config.seismic = true;
-        config.no_seismic_warnings = false;
         config.ignored_error_codes = vec![
             SolidityErrorCode::SpdxLicenseNotProvided,
             // suppress pre-release warning so it doesn't interfere
@@ -1429,8 +1425,7 @@ contract Receiver {
 "#,
     );
 
-    // Same patterns but in test/ — ext-call warnings (5506) should be auto-suppressed
-    // by seismic-compilers, but constructor (5500) and new-expr (5501) should remain
+    // Test file — all seismic warnings should be suppressed by default
     prj.add_raw_source(
         "test/Caller.t.sol",
         r#"
@@ -1442,39 +1437,27 @@ import {Receiver} from "../src/Receiver.sol";
 contract CallerTest {
     Receiver public r;
     constructor() {
-        // 5501 (new-expr) — NOT suppressed, CREATE always leaks
         r = new Receiver(suint256(42));
     }
     function testCallWithLiteral() external {
-        // 5506 (ext-call) — suppressed in test files
         r.setVal(suint256(100));
     }
 }
 "#,
     );
 
+    // Build should succeed with no seismic warnings from test files
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // 5500 (constructor param) and 5501 (new-expr) should still appear
     assert!(
-        stdout.contains("Warning (5500)"),
-        "expected warning 5500 (shielded-constructor-param) even in test/ file:\n{stdout}"
-    );
-    assert!(
-        stdout.contains("Warning (5501)"),
-        "expected warning 5501 (shielded-literal-new-int) even in test/ file:\n{stdout}"
-    );
-
-    // 5506 (ext-call) should be suppressed by seismic-compilers in test/ files
-    assert!(
-        !stdout.contains("Warning (5506)"),
-        "warning 5506 (shielded-literal-ext-call-int) should be suppressed in test/ file:\n{stdout}"
+        !stdout.contains("Warning (10103)") && !stdout.contains("Warning (10401)")
+            && !stdout.contains("Warning (10402)"),
+        "seismic warnings from test/ files should be suppressed by default:\n{stdout}"
     );
 });
 
-// test that seismic-compilers suppresses ext-call shielded warnings in script/ files
-forgetest!(shielded_literal_warnings_suppressed_in_script, |prj, cmd| {
+// test that seismic warnings are shown in script/ files (scripts behave like src/)
+forgetest!(shielded_literal_warnings_shown_in_script, |prj, cmd| {
     // Skip if ssolc is not installed
     if std::process::Command::new("ssolc").arg("--version").output().is_err() {
         eprintln!("skipping test: ssolc not found in PATH");
@@ -1483,7 +1466,6 @@ forgetest!(shielded_literal_warnings_suppressed_in_script, |prj, cmd| {
 
     prj.update_config(|config| {
         config.seismic = true;
-        config.no_seismic_warnings = false;
         config.ignored_error_codes =
             vec![SolidityErrorCode::SpdxLicenseNotProvided, SolidityErrorCode::Other(3805)];
     });
@@ -1503,7 +1485,7 @@ contract Receiver {
 "#,
     );
 
-    // Same patterns in script/ — ext-call warnings should be suppressed
+    // Script file — all seismic warnings should be shown (scripts are like src/)
     prj.add_raw_source(
         "script/Deploy.s.sol",
         r#"
@@ -1515,11 +1497,9 @@ import {Receiver} from "../src/Receiver.sol";
 contract DeployScript {
     Receiver public r;
     constructor() {
-        // 5501 (new-expr) — NOT suppressed
         r = new Receiver(suint256(42));
     }
     function run() external {
-        // 5506 (ext-call) — suppressed in script files
         r.setVal(suint256(100));
     }
 }
@@ -1529,20 +1509,18 @@ contract DeployScript {
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // 5500 and 5501 should still appear
+    // All seismic warnings should be visible in script/ files
     assert!(
-        stdout.contains("Warning (5500)"),
-        "expected warning 5500 (shielded-constructor-param) even in script/ file:\n{stdout}"
+        stdout.contains("Warning (10103)"),
+        "expected warning 10103 in script/ file:\n{stdout}"
     );
     assert!(
-        stdout.contains("Warning (5501)"),
-        "expected warning 5501 (shielded-literal-new-int) even in script/ file:\n{stdout}"
+        stdout.contains("Warning (10401)"),
+        "expected warning 10401 in script/ file:\n{stdout}"
     );
-
-    // 5506 should be suppressed
     assert!(
-        !stdout.contains("Warning (5506)"),
-        "warning 5506 (shielded-literal-ext-call-int) should be suppressed in script/ file:\n{stdout}"
+        stdout.contains("Warning (10402)"),
+        "expected warning 10402 in script/ file:\n{stdout}"
     );
 });
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1305,8 +1305,8 @@ Compiler run successful!
 // test that ssolc shielded literal warnings (5500–5510) are emitted in src/ and can be suppressed
 forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
     // Skip if ssolc is not installed
-    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
-        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+    if std::process::Command::new("ssolc").arg("--version").output().is_err() {
+        eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
 
@@ -1396,8 +1396,8 @@ contract Caller {
 // but still emits constructor/new-expr warnings (CREATE always leaks, even in tests)
 forgetest!(shielded_literal_warnings_suppressed_in_test, |prj, cmd| {
     // Skip if ssolc is not installed
-    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
-        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+    if std::process::Command::new("ssolc").arg("--version").output().is_err() {
+        eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
 
@@ -1472,8 +1472,8 @@ contract CallerTest {
 // test that seismic-compilers suppresses ext-call shielded warnings in script/ files
 forgetest!(shielded_literal_warnings_suppressed_in_script, |prj, cmd| {
     // Skip if ssolc is not installed
-    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
-        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+    if std::process::Command::new("ssolc").arg("--version").output().is_err() {
+        eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1310,9 +1310,11 @@ forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
         return;
     }
 
-    // Enable seismic (ssolc) and suppress unrelated warnings
+    // Enable seismic (ssolc), disable --no-seismic-warnings so warnings are visible,
+    // and suppress unrelated warnings
     prj.update_config(|config| {
         config.seismic = true;
+        config.no_seismic_warnings = false;
         config.ignored_error_codes = vec![SolidityErrorCode::SpdxLicenseNotProvided];
     });
 
@@ -1373,6 +1375,7 @@ contract Caller {
     // Now suppress all shielded warnings and the pre-release warning, then rebuild
     prj.update_config(|config| {
         config.seismic = true;
+        config.no_seismic_warnings = false;
         config.ignored_error_codes = vec![
             SolidityErrorCode::SpdxLicenseNotProvided,
             SolidityErrorCode::ShieldedConstructorParam,
@@ -1403,6 +1406,7 @@ forgetest!(shielded_literal_warnings_suppressed_in_test, |prj, cmd| {
 
     prj.update_config(|config| {
         config.seismic = true;
+        config.no_seismic_warnings = false;
         config.ignored_error_codes = vec![
             SolidityErrorCode::SpdxLicenseNotProvided,
             // suppress pre-release warning so it doesn't interfere
@@ -1479,6 +1483,7 @@ forgetest!(shielded_literal_warnings_suppressed_in_script, |prj, cmd| {
 
     prj.update_config(|config| {
         config.seismic = true;
+        config.no_seismic_warnings = false;
         config.ignored_error_codes =
             vec![SolidityErrorCode::SpdxLicenseNotProvided, SolidityErrorCode::Other(3805)];
     });

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1456,7 +1456,7 @@ contract CallerTest {
     );
 });
 
-// test that seismic warnings are shown in script/ files (scripts behave like src/)
+// test that seismic warnings in script/ files: constructor/new-expr shown, ext-call suppressed
 forgetest!(shielded_literal_warnings_shown_in_script, |prj, cmd| {
     // Skip if ssolc is not installed
     if std::process::Command::new("ssolc").arg("--version").output().is_err() {
@@ -1485,7 +1485,7 @@ contract Receiver {
 "#,
     );
 
-    // Script file — all seismic warnings should be shown (scripts are like src/)
+    // Script file — constructor/new-expr warnings shown, ext-call suppressed
     prj.add_raw_source(
         "script/Deploy.s.sol",
         r#"
@@ -1509,18 +1509,19 @@ contract DeployScript {
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // All seismic warnings should be visible in script/ files
+    // Constructor and new-expr warnings should be visible in script/ files
     assert!(
         stdout.contains("Warning (10103)"),
-        "expected warning 10103 in script/ file:\n{stdout}"
+        "expected warning 10103 (constructor param) in script/ file:\n{stdout}"
     );
     assert!(
         stdout.contains("Warning (10401)"),
-        "expected warning 10401 in script/ file:\n{stdout}"
+        "expected warning 10401 (new-expr) in script/ file:\n{stdout}"
     );
+    // Ext-call warnings should be suppressed in script/ files
     assert!(
-        stdout.contains("Warning (10402)"),
-        "expected warning 10402 in script/ file:\n{stdout}"
+        !stdout.contains("Warning (10402)"),
+        "warning 10402 (ext-call) should be suppressed in script/ file:\n{stdout}"
     );
 });
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -179,7 +179,8 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         script_execution_protection: true,
         _non_exhaustive: (),
         seismic: true,
-        no_seismic_warnings: true,
+        no_seismic_warnings: false,
+        seismic_warnings_test: false,
     };
     prj.write_config(input.clone());
     let config = cmd.config();

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -179,6 +179,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         script_execution_protection: true,
         _non_exhaustive: (),
         seismic: true,
+        no_seismic_warnings: true,
     };
     prj.write_config(input.clone());
     let config = cmd.config();

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3253,11 +3253,11 @@ Error: script failed: vm.load: attempted to read private storage slot [..] at ad
 
 // Test that sforge script --broadcast encrypts calldata for functions with shielded params
 // and redacts arguments in broadcast JSON.
-// Requires: ssolc installed at /usr/local/bin/ssolc, sanvil with --seismic
+// Requires: ssolc in PATH, sanvil with --seismic
 forgetest_async!(seismic_broadcast_encrypts_shielded_function_calls, |prj, cmd| {
     // Skip if ssolc is not installed
-    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
-        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+    if std::process::Command::new("ssolc").arg("--version").output().is_err() {
+        eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
 


### PR DESCRIPTION
## Summary

Three improvements to how sforge interacts with ssolc, organized as separate commits:

- **Resolve ssolc from PATH** instead of hardcoded `/usr/local/bin/ssolc`. Also fixes `ensure_solc()` to always use ssolc when seismic mode is active (previously fell through to upstream auto-detect/download of standard solc when no `solc` was configured).
- **Auto-enable `--unsafe-via-ir`** when `via_ir = true` in seismic mode. ssolc requires both flags for the IR pipeline — now users just set `via_ir = true` and it works.
- **Add `no_seismic_warnings` config** (default `true`). Automatically passes `--no-seismic-warnings` to ssolc to suppress shielded-literal warnings globally. Opt out with `no_seismic_warnings = false` in `foundry.toml`.

## Test plan

- [x] `cargo check --bin sforge` passes
- [x] `cargo check --bin sanvil` passes
- [x] `cargo check --tests -p forge` passes
- [ ] CI: `cargo nextest run test_seismic_` (existing seismic tests)
- [ ] CI: shielded warning tests with `no_seismic_warnings = false` set explicitly
- [ ] Manual: verify `ssolc` resolves from PATH on clean install