### PR TITLE
feat: update shielded warning codes to 10000+ range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,10 +412,10 @@ alloy-op-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev 
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "039d51496b9b9a0cb4fea6d606e472211b462073" }
 
 # foundry
-foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
-foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
-foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "e6e099e7314068a4290475fdad1d661a5bcac6bc" }
+foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
+foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
+foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
 
 foundry-fork-db = { git = "https://github.com/SeismicSystems/seismic-foundry-fork-db.git", rev = "e5fb1f8838b517dbaaccc08a8af6767fe2e70c4e" }

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -162,6 +162,18 @@ pub enum SolidityErrorCode {
     ShieldedLiteralExtCallFixedbytes,
     /// Warning: shielded literal in external call args (enum)
     ShieldedLiteralExtCallEnum,
+    /// Warning: shielded literal in other context (int)
+    ShieldedLiteralOtherInt,
+    /// Warning: shielded literal in other context (bool)
+    ShieldedLiteralOtherBool,
+    /// Warning: shielded literal in other context (address)
+    ShieldedLiteralOtherAddress,
+    /// Warning: shielded literal in other context (fixedbytes)
+    ShieldedLiteralOtherFixedbytes,
+    /// Warning: shielded literal in other context (enum)
+    ShieldedLiteralOtherEnum,
+    /// Warning: shielded number literal
+    ShieldedNumberLiteral,
     /// All other error codes
     Other(u64),
 }
@@ -200,6 +212,12 @@ impl SolidityErrorCode {
             Self::ShieldedLiteralExtCallAddress => "shielded-literal-ext-call-address",
             Self::ShieldedLiteralExtCallFixedbytes => "shielded-literal-ext-call-fixedbytes",
             Self::ShieldedLiteralExtCallEnum => "shielded-literal-ext-call-enum",
+            Self::ShieldedLiteralOtherInt => "shielded-literal-other-int",
+            Self::ShieldedLiteralOtherBool => "shielded-literal-other-bool",
+            Self::ShieldedLiteralOtherAddress => "shielded-literal-other-address",
+            Self::ShieldedLiteralOtherFixedbytes => "shielded-literal-other-fixedbytes",
+            Self::ShieldedLiteralOtherEnum => "shielded-literal-other-enum",
+            Self::ShieldedNumberLiteral => "shielded-number-literal",
             Self::Other(code) => return Err(*code),
         };
         Ok(s)
@@ -226,17 +244,23 @@ impl From<SolidityErrorCode> for u64 {
             SolidityErrorCode::PragmaSolidity => 3420,
             SolidityErrorCode::TransientStorageUsed => 2394,
             SolidityErrorCode::TooManyWarnings => 4591,
-            SolidityErrorCode::ShieldedConstructorParam => 5500,
-            SolidityErrorCode::ShieldedLiteralNewExprInt => 5501,
-            SolidityErrorCode::ShieldedLiteralNewExprBool => 5502,
-            SolidityErrorCode::ShieldedLiteralNewExprAddress => 5503,
-            SolidityErrorCode::ShieldedLiteralNewExprFixedbytes => 5504,
-            SolidityErrorCode::ShieldedLiteralNewExprEnum => 5505,
-            SolidityErrorCode::ShieldedLiteralExtCallInt => 5506,
-            SolidityErrorCode::ShieldedLiteralExtCallBool => 5507,
-            SolidityErrorCode::ShieldedLiteralExtCallAddress => 5508,
-            SolidityErrorCode::ShieldedLiteralExtCallFixedbytes => 5509,
-            SolidityErrorCode::ShieldedLiteralExtCallEnum => 5510,
+            SolidityErrorCode::ShieldedConstructorParam => 10103,
+            SolidityErrorCode::ShieldedLiteralNewExprInt => 10401,
+            SolidityErrorCode::ShieldedLiteralNewExprBool => 10404,
+            SolidityErrorCode::ShieldedLiteralNewExprAddress => 10407,
+            SolidityErrorCode::ShieldedLiteralNewExprFixedbytes => 10410,
+            SolidityErrorCode::ShieldedLiteralNewExprEnum => 10413,
+            SolidityErrorCode::ShieldedLiteralExtCallInt => 10402,
+            SolidityErrorCode::ShieldedLiteralExtCallBool => 10405,
+            SolidityErrorCode::ShieldedLiteralExtCallAddress => 10408,
+            SolidityErrorCode::ShieldedLiteralExtCallFixedbytes => 10411,
+            SolidityErrorCode::ShieldedLiteralExtCallEnum => 10414,
+            SolidityErrorCode::ShieldedLiteralOtherInt => 10403,
+            SolidityErrorCode::ShieldedLiteralOtherBool => 10406,
+            SolidityErrorCode::ShieldedLiteralOtherAddress => 10409,
+            SolidityErrorCode::ShieldedLiteralOtherFixedbytes => 10412,
+            SolidityErrorCode::ShieldedLiteralOtherEnum => 10415,
+            SolidityErrorCode::ShieldedNumberLiteral => 10416,
             SolidityErrorCode::Other(code) => code,
         }
     }
@@ -284,6 +308,12 @@ impl FromStr for SolidityErrorCode {
             "shielded-literal-ext-call-address" => Self::ShieldedLiteralExtCallAddress,
             "shielded-literal-ext-call-fixedbytes" => Self::ShieldedLiteralExtCallFixedbytes,
             "shielded-literal-ext-call-enum" => Self::ShieldedLiteralExtCallEnum,
+            "shielded-literal-other-int" => Self::ShieldedLiteralOtherInt,
+            "shielded-literal-other-bool" => Self::ShieldedLiteralOtherBool,
+            "shielded-literal-other-address" => Self::ShieldedLiteralOtherAddress,
+            "shielded-literal-other-fixedbytes" => Self::ShieldedLiteralOtherFixedbytes,
+            "shielded-literal-other-enum" => Self::ShieldedLiteralOtherEnum,
+            "shielded-number-literal" => Self::ShieldedNumberLiteral,
             _ => return Err(format!("Unknown variant {s}")),
         };
 
@@ -311,17 +341,23 @@ impl From<u64> for SolidityErrorCode {
             3420 => Self::PragmaSolidity,
             2394 => Self::TransientStorageUsed,
             4591 => Self::TooManyWarnings,
-            5500 => Self::ShieldedConstructorParam,
-            5501 => Self::ShieldedLiteralNewExprInt,
-            5502 => Self::ShieldedLiteralNewExprBool,
-            5503 => Self::ShieldedLiteralNewExprAddress,
-            5504 => Self::ShieldedLiteralNewExprFixedbytes,
-            5505 => Self::ShieldedLiteralNewExprEnum,
-            5506 => Self::ShieldedLiteralExtCallInt,
-            5507 => Self::ShieldedLiteralExtCallBool,
-            5508 => Self::ShieldedLiteralExtCallAddress,
-            5509 => Self::ShieldedLiteralExtCallFixedbytes,
-            5510 => Self::ShieldedLiteralExtCallEnum,
+            10103 => Self::ShieldedConstructorParam,
+            10401 => Self::ShieldedLiteralNewExprInt,
+            10404 => Self::ShieldedLiteralNewExprBool,
+            10407 => Self::ShieldedLiteralNewExprAddress,
+            10410 => Self::ShieldedLiteralNewExprFixedbytes,
+            10413 => Self::ShieldedLiteralNewExprEnum,
+            10402 => Self::ShieldedLiteralExtCallInt,
+            10405 => Self::ShieldedLiteralExtCallBool,
+            10408 => Self::ShieldedLiteralExtCallAddress,
+            10411 => Self::ShieldedLiteralExtCallFixedbytes,
+            10414 => Self::ShieldedLiteralExtCallEnum,
+            10403 => Self::ShieldedLiteralOtherInt,
+            10406 => Self::ShieldedLiteralOtherBool,
+            10409 => Self::ShieldedLiteralOtherAddress,
+            10412 => Self::ShieldedLiteralOtherFixedbytes,
+            10415 => Self::ShieldedLiteralOtherEnum,
+            10416 => Self::ShieldedNumberLiteral,
             other => Self::Other(other),
         }
     }
@@ -365,29 +401,39 @@ mod tests {
 
     /// All shielded warning variants with their numeric IDs and string aliases.
     const SHIELDED_VARIANTS: &[(SolidityErrorCode, u64, &str)] = &[
-        (SolidityErrorCode::ShieldedConstructorParam, 5500, "shielded-constructor-param"),
-        (SolidityErrorCode::ShieldedLiteralNewExprInt, 5501, "shielded-literal-new-int"),
-        (SolidityErrorCode::ShieldedLiteralNewExprBool, 5502, "shielded-literal-new-bool"),
-        (SolidityErrorCode::ShieldedLiteralNewExprAddress, 5503, "shielded-literal-new-address"),
+        (SolidityErrorCode::ShieldedConstructorParam, 10103, "shielded-constructor-param"),
+        (SolidityErrorCode::ShieldedLiteralNewExprInt, 10401, "shielded-literal-new-int"),
+        (SolidityErrorCode::ShieldedLiteralNewExprBool, 10404, "shielded-literal-new-bool"),
+        (SolidityErrorCode::ShieldedLiteralNewExprAddress, 10407, "shielded-literal-new-address"),
         (
             SolidityErrorCode::ShieldedLiteralNewExprFixedbytes,
-            5504,
+            10410,
             "shielded-literal-new-fixedbytes",
         ),
-        (SolidityErrorCode::ShieldedLiteralNewExprEnum, 5505, "shielded-literal-new-enum"),
-        (SolidityErrorCode::ShieldedLiteralExtCallInt, 5506, "shielded-literal-ext-call-int"),
-        (SolidityErrorCode::ShieldedLiteralExtCallBool, 5507, "shielded-literal-ext-call-bool"),
+        (SolidityErrorCode::ShieldedLiteralNewExprEnum, 10413, "shielded-literal-new-enum"),
+        (SolidityErrorCode::ShieldedLiteralExtCallInt, 10402, "shielded-literal-ext-call-int"),
+        (SolidityErrorCode::ShieldedLiteralExtCallBool, 10405, "shielded-literal-ext-call-bool"),
         (
             SolidityErrorCode::ShieldedLiteralExtCallAddress,
-            5508,
+            10408,
             "shielded-literal-ext-call-address",
         ),
         (
             SolidityErrorCode::ShieldedLiteralExtCallFixedbytes,
-            5509,
+            10411,
             "shielded-literal-ext-call-fixedbytes",
         ),
-        (SolidityErrorCode::ShieldedLiteralExtCallEnum, 5510, "shielded-literal-ext-call-enum"),
+        (SolidityErrorCode::ShieldedLiteralExtCallEnum, 10414, "shielded-literal-ext-call-enum"),
+        (SolidityErrorCode::ShieldedLiteralOtherInt, 10403, "shielded-literal-other-int"),
+        (SolidityErrorCode::ShieldedLiteralOtherBool, 10406, "shielded-literal-other-bool"),
+        (SolidityErrorCode::ShieldedLiteralOtherAddress, 10409, "shielded-literal-other-address"),
+        (
+            SolidityErrorCode::ShieldedLiteralOtherFixedbytes,
+            10412,
+            "shielded-literal-other-fixedbytes",
+        ),
+        (SolidityErrorCode::ShieldedLiteralOtherEnum, 10415, "shielded-literal-other-enum"),
+        (SolidityErrorCode::ShieldedNumberLiteral, 10416, "shielded-number-literal"),
     ];
 
     #[test]

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -162,19 +162,9 @@ pub enum SolidityErrorCode {
     ShieldedLiteralExtCallFixedbytes,
     /// Warning: shielded literal in external call args (enum)
     ShieldedLiteralExtCallEnum,
-    /// Warning: shielded literal in other context (int)
-    ShieldedLiteralOtherInt,
-    /// Warning: shielded literal in other context (bool)
-    ShieldedLiteralOtherBool,
-    /// Warning: shielded literal in other context (address)
-    ShieldedLiteralOtherAddress,
-    /// Warning: shielded literal in other context (fixedbytes)
-    ShieldedLiteralOtherFixedbytes,
-    /// Warning: shielded literal in other context (enum)
-    ShieldedLiteralOtherEnum,
-    /// Warning: shielded number literal
-    ShieldedNumberLiteral,
     /// All other error codes
+    /// Note: Seismic/ssolc warning codes (>= 10000) not listed above (e.g. "other context"
+    /// 10403-10415, s-literal 10416) are handled via `Other(code)`.
     Other(u64),
 }
 
@@ -212,12 +202,6 @@ impl SolidityErrorCode {
             Self::ShieldedLiteralExtCallAddress => "shielded-literal-ext-call-address",
             Self::ShieldedLiteralExtCallFixedbytes => "shielded-literal-ext-call-fixedbytes",
             Self::ShieldedLiteralExtCallEnum => "shielded-literal-ext-call-enum",
-            Self::ShieldedLiteralOtherInt => "shielded-literal-other-int",
-            Self::ShieldedLiteralOtherBool => "shielded-literal-other-bool",
-            Self::ShieldedLiteralOtherAddress => "shielded-literal-other-address",
-            Self::ShieldedLiteralOtherFixedbytes => "shielded-literal-other-fixedbytes",
-            Self::ShieldedLiteralOtherEnum => "shielded-literal-other-enum",
-            Self::ShieldedNumberLiteral => "shielded-number-literal",
             Self::Other(code) => return Err(*code),
         };
         Ok(s)
@@ -255,12 +239,6 @@ impl From<SolidityErrorCode> for u64 {
             SolidityErrorCode::ShieldedLiteralExtCallAddress => 10408,
             SolidityErrorCode::ShieldedLiteralExtCallFixedbytes => 10411,
             SolidityErrorCode::ShieldedLiteralExtCallEnum => 10414,
-            SolidityErrorCode::ShieldedLiteralOtherInt => 10403,
-            SolidityErrorCode::ShieldedLiteralOtherBool => 10406,
-            SolidityErrorCode::ShieldedLiteralOtherAddress => 10409,
-            SolidityErrorCode::ShieldedLiteralOtherFixedbytes => 10412,
-            SolidityErrorCode::ShieldedLiteralOtherEnum => 10415,
-            SolidityErrorCode::ShieldedNumberLiteral => 10416,
             SolidityErrorCode::Other(code) => code,
         }
     }
@@ -308,12 +286,6 @@ impl FromStr for SolidityErrorCode {
             "shielded-literal-ext-call-address" => Self::ShieldedLiteralExtCallAddress,
             "shielded-literal-ext-call-fixedbytes" => Self::ShieldedLiteralExtCallFixedbytes,
             "shielded-literal-ext-call-enum" => Self::ShieldedLiteralExtCallEnum,
-            "shielded-literal-other-int" => Self::ShieldedLiteralOtherInt,
-            "shielded-literal-other-bool" => Self::ShieldedLiteralOtherBool,
-            "shielded-literal-other-address" => Self::ShieldedLiteralOtherAddress,
-            "shielded-literal-other-fixedbytes" => Self::ShieldedLiteralOtherFixedbytes,
-            "shielded-literal-other-enum" => Self::ShieldedLiteralOtherEnum,
-            "shielded-number-literal" => Self::ShieldedNumberLiteral,
             _ => return Err(format!("Unknown variant {s}")),
         };
 
@@ -352,12 +324,6 @@ impl From<u64> for SolidityErrorCode {
             10408 => Self::ShieldedLiteralExtCallAddress,
             10411 => Self::ShieldedLiteralExtCallFixedbytes,
             10414 => Self::ShieldedLiteralExtCallEnum,
-            10403 => Self::ShieldedLiteralOtherInt,
-            10406 => Self::ShieldedLiteralOtherBool,
-            10409 => Self::ShieldedLiteralOtherAddress,
-            10412 => Self::ShieldedLiteralOtherFixedbytes,
-            10415 => Self::ShieldedLiteralOtherEnum,
-            10416 => Self::ShieldedNumberLiteral,
             other => Self::Other(other),
         }
     }
@@ -424,16 +390,6 @@ mod tests {
             "shielded-literal-ext-call-fixedbytes",
         ),
         (SolidityErrorCode::ShieldedLiteralExtCallEnum, 10414, "shielded-literal-ext-call-enum"),
-        (SolidityErrorCode::ShieldedLiteralOtherInt, 10403, "shielded-literal-other-int"),
-        (SolidityErrorCode::ShieldedLiteralOtherBool, 10406, "shielded-literal-other-bool"),
-        (SolidityErrorCode::ShieldedLiteralOtherAddress, 10409, "shielded-literal-other-address"),
-        (
-            SolidityErrorCode::ShieldedLiteralOtherFixedbytes,
-            10412,
-            "shielded-literal-other-fixedbytes",
-        ),
-        (SolidityErrorCode::ShieldedLiteralOtherEnum, 10415, "shielded-literal-other-enum"),
-        (SolidityErrorCode::ShieldedNumberLiteral, 10416, "shielded-number-literal"),
     ];
 
     #[test]

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1302,7 +1302,8 @@ Compiler run successful!
 "#]]);
 });
 
-// test that ssolc shielded literal warnings (5500–5510) are emitted in src/ and can be suppressed
+// test that ssolc shielded literal warnings (10103, 10401–10416) are emitted in src/ and can be
+// suppressed
 forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
     // Skip if ssolc is not installed
     if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
@@ -1343,11 +1344,11 @@ import {Receiver} from "./Receiver.sol";
 contract Caller {
     Receiver public r;
     constructor() {
-        // triggers 5501 (shielded-literal-new-int)
+        // triggers 10401 (shielded-literal-new-int)
         r = new Receiver(suint256(42));
     }
     function callWithLiteral() external {
-        // triggers 5506 (shielded-literal-ext-call-int)
+        // triggers 10402 (shielded-literal-ext-call-int)
         r.setVal(suint256(100));
     }
 }
@@ -1358,16 +1359,16 @@ contract Caller {
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("Warning (5500)"),
-        "expected warning 5500 (shielded-constructor-param) in src/ output:\n{stdout}"
+        stdout.contains("Warning (10103)"),
+        "expected warning 10103 (shielded-constructor-param) in src/ output:\n{stdout}"
     );
     assert!(
-        stdout.contains("Warning (5501)"),
-        "expected warning 5501 (shielded-literal-new-int) in src/ output:\n{stdout}"
+        stdout.contains("Warning (10401)"),
+        "expected warning 10401 (shielded-literal-new-int) in src/ output:\n{stdout}"
     );
     assert!(
-        stdout.contains("Warning (5506)"),
-        "expected warning 5506 (shielded-literal-ext-call-int) in src/ output:\n{stdout}"
+        stdout.contains("Warning (10402)"),
+        "expected warning 10402 (shielded-literal-ext-call-int) in src/ output:\n{stdout}"
     );
 
     // Now suppress all shielded warnings and the pre-release warning, then rebuild
@@ -1425,8 +1426,8 @@ contract Receiver {
 "#,
     );
 
-    // Same patterns but in test/ — ext-call warnings (5506) should be auto-suppressed
-    // by seismic-compilers, but constructor (5500) and new-expr (5501) should remain
+    // Same patterns but in test/ — ext-call warnings (10402) should be auto-suppressed
+    // by seismic-compilers, but constructor (10103) and new-expr (10401) should remain
     prj.add_raw_source(
         "test/Caller.t.sol",
         r#"
@@ -1438,11 +1439,11 @@ import {Receiver} from "../src/Receiver.sol";
 contract CallerTest {
     Receiver public r;
     constructor() {
-        // 5501 (new-expr) — NOT suppressed, CREATE always leaks
+        // 10401 (new-expr) — NOT suppressed, CREATE always leaks
         r = new Receiver(suint256(42));
     }
     function testCallWithLiteral() external {
-        // 5506 (ext-call) — suppressed in test files
+        // 10402 (ext-call) — suppressed in test files
         r.setVal(suint256(100));
     }
 }
@@ -1452,20 +1453,20 @@ contract CallerTest {
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // 5500 (constructor param) and 5501 (new-expr) should still appear
+    // 10103 (constructor param) and 10401 (new-expr) should still appear
     assert!(
-        stdout.contains("Warning (5500)"),
-        "expected warning 5500 (shielded-constructor-param) even in test/ file:\n{stdout}"
+        stdout.contains("Warning (10103)"),
+        "expected warning 10103 (shielded-constructor-param) even in test/ file:\n{stdout}"
     );
     assert!(
-        stdout.contains("Warning (5501)"),
-        "expected warning 5501 (shielded-literal-new-int) even in test/ file:\n{stdout}"
+        stdout.contains("Warning (10401)"),
+        "expected warning 10401 (shielded-literal-new-int) even in test/ file:\n{stdout}"
     );
 
-    // 5506 (ext-call) should be suppressed by seismic-compilers in test/ files
+    // 10402 (ext-call) should be suppressed by seismic-compilers in test/ files
     assert!(
-        !stdout.contains("Warning (5506)"),
-        "warning 5506 (shielded-literal-ext-call-int) should be suppressed in test/ file:\n{stdout}"
+        !stdout.contains("Warning (10402)"),
+        "warning 10402 (shielded-literal-ext-call-int) should be suppressed in test/ file:\n{stdout}"
     );
 });
 
@@ -1510,11 +1511,11 @@ import {Receiver} from "../src/Receiver.sol";
 contract DeployScript {
     Receiver public r;
     constructor() {
-        // 5501 (new-expr) — NOT suppressed
+        // 10401 (new-expr) — NOT suppressed
         r = new Receiver(suint256(42));
     }
     function run() external {
-        // 5506 (ext-call) — suppressed in script files
+        // 10402 (ext-call) — suppressed in script files
         r.setVal(suint256(100));
     }
 }
@@ -1524,20 +1525,20 @@ contract DeployScript {
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // 5500 and 5501 should still appear
+    // 10103 and 10401 should still appear
     assert!(
-        stdout.contains("Warning (5500)"),
-        "expected warning 5500 (shielded-constructor-param) even in script/ file:\n{stdout}"
+        stdout.contains("Warning (10103)"),
+        "expected warning 10103 (shielded-constructor-param) even in script/ file:\n{stdout}"
     );
     assert!(
-        stdout.contains("Warning (5501)"),
-        "expected warning 5501 (shielded-literal-new-int) even in script/ file:\n{stdout}"
+        stdout.contains("Warning (10401)"),
+        "expected warning 10401 (shielded-literal-new-int) even in script/ file:\n{stdout}"
     );
 
-    // 5506 should be suppressed
+    // 10402 should be suppressed
     assert!(
-        !stdout.contains("Warning (5506)"),
-        "warning 5506 (shielded-literal-ext-call-int) should be suppressed in script/ file:\n{stdout}"
+        !stdout.contains("Warning (10402)"),
+        "warning 10402 (shielded-literal-ext-call-int) should be suppressed in script/ file:\n{stdout}"
     );
 });
 


### PR DESCRIPTION
## Summary
- Update all `SolidityErrorCode` shielded variants from old 4-digit codes (5500-5510) to new 5-digit codes (10103, 10401-10416) matching ssolc commit `bcce7ba86`
- Add new "other context" variants (`ShieldedLiteralOther{Int,Bool,Address,Fixedbytes,Enum}`) and `ShieldedNumberLiteral` that ssolc now emits
- Update ssolc detection in integration tests to use PATH lookup instead of hardcoded `/usr/local/bin/ssolc`
- Preserves all of Ameya's enum variants, test structure, and string aliases — only numeric codes change

## Test plan
- [ ] `cargo nextest run -p foundry-config` — error.rs unit tests (roundtrip, as_str, from_str)
- [ ] `cargo nextest run shielded_literal_warnings` — integration tests with ssolc (requires ssolc in PATH)