### PR TITLE
feat: resolve ssolc from PATH instead of hardcoded location

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1127,21 +1127,23 @@ impl Config {
         Ok(())
     }
 
-    /// Get default ssolc path
+    /// Resolve path to `ssolc` binary by searching the system PATH.
     #[inline]
     pub fn get_default_ssolc_path(&self) -> Result<PathBuf, SolcError> {
-        let default_solc_path = if cfg!(windows) {
-            PathBuf::from("C:\\Program Files\\Seismic\\bin\\ssolc.exe")
-        } else {
-            PathBuf::from("/usr/local/bin/ssolc")
-        };
-        if !default_solc_path.is_file() {
-            return Err(SolcError::msg(format!(
-                "`ssolc` {} does not exist.\nInstructions to install:\nhttps://docs.seismic.systems/getting-started/publish-your-docs#install-the-local-development-suite",
-                default_solc_path.display()
-            )));
-        }
-        Ok(default_solc_path)
+        let path = PathBuf::from("ssolc");
+        // Verify ssolc is reachable (Command::new resolves from PATH).
+        std::process::Command::new(&path)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map_err(|_| {
+                SolcError::msg(
+                    "`ssolc` not found in PATH.\n\
+                     Install via: https://docs.seismic.systems/getting-started/installation",
+                )
+            })?;
+        Ok(path)
     }
 
     /// Ensures that the configured version is installed if explicitly set
@@ -1155,10 +1157,10 @@ impl Config {
             if let Some(ref solc_req) = self.solc {
                 match solc_req {
                     SolcReq::Version(_) => {
-                        // Only allow the version they have downloaded
-                        // TODO: support using different versions
-                        let default_solc_path = self.get_default_ssolc_path()?;
-                        return Ok(Some(Solc::new(default_solc_path)?));
+                        // TODO: support using different ssolc versions
+                        // For now, ignore the version request — use ssolc from PATH
+                        let ssolc_path = self.get_default_ssolc_path()?;
+                        return Ok(Some(Solc::new(ssolc_path)?));
                     }
                     SolcReq::Local(local_solc_path) => {
                         if !local_solc_path.is_file() {
@@ -1171,6 +1173,9 @@ impl Config {
                     }
                 }
             }
+            // No solc explicitly configured — find ssolc in PATH
+            let ssolc_path = self.get_default_ssolc_path()?;
+            return Ok(Some(Solc::new(ssolc_path)?));
         }
 
         if let Some(solc) = &self.solc {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1156,10 +1156,17 @@ impl Config {
         if self.seismic {
             if let Some(ref solc_req) = self.solc {
                 match solc_req {
-                    SolcReq::Version(_) => {
+                    SolcReq::Version(v) => {
                         // TODO: support using different ssolc versions
-                        // For now, ignore the version request — use ssolc from PATH
                         let ssolc_path = self.get_default_ssolc_path()?;
+                        eprintln!(
+                            "{}",
+                            yansi::Paint::yellow(&format!(
+                                "Warning: ssolc does not support version selection \
+                                 (requested {v}), using `{}`",
+                                ssolc_path.display()
+                            ))
+                        );
                         return Ok(Some(Solc::new(ssolc_path)?));
                     }
                     SolcReq::Local(local_solc_path) => {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2426,7 +2426,9 @@ impl Default for Config {
             gas_reports: vec!["*".to_string()],
             gas_reports_ignore: vec![],
             gas_reports_include_tests: false,
-            solc: Some(SolcReq::Version(Version::parse("0.8.31").unwrap())),
+            // TODO: restore version pinning when ssolc supports version selection
+            // (see https://github.com/SeismicSystems/seismic-foundry/issues/186)
+            solc: None,
             vyper: Default::default(),
             auto_detect_solc: true,
             offline: false,

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1302,17 +1302,21 @@ Compiler run successful!
 "#]]);
 });
 
-// test that ssolc shielded literal warnings (10103, 10401–10416) are emitted in src/ and can be
-// suppressed
-forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
-    // Skip if ssolc is not installed
-    if std::process::Command::new("ssolc")
+/// Returns `true` if `ssolc` is available in PATH.
+fn has_ssolc() -> bool {
+    std::process::Command::new("ssolc")
         .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .is_err()
-    {
+        .is_ok()
+}
+
+// test that ssolc shielded literal warnings (10103, 10401–10416) are emitted in src/ and can be
+// suppressed
+forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
+    // Skip if ssolc is not installed
+    if !has_ssolc() {
         eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
@@ -1403,13 +1407,7 @@ contract Caller {
 // but still emits constructor/new-expr warnings (CREATE always leaks, even in tests)
 forgetest!(shielded_literal_warnings_suppressed_in_test, |prj, cmd| {
     // Skip if ssolc is not installed
-    if std::process::Command::new("ssolc")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_err()
-    {
+    if !has_ssolc() {
         eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
@@ -1485,13 +1483,7 @@ contract CallerTest {
 // test that seismic-compilers suppresses ext-call shielded warnings in script/ files
 forgetest!(shielded_literal_warnings_suppressed_in_script, |prj, cmd| {
     // Skip if ssolc is not installed
-    if std::process::Command::new("ssolc")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_err()
-    {
+    if !has_ssolc() {
         eprintln!("skipping test: ssolc not found in PATH");
         return;
     }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1306,8 +1306,14 @@ Compiler run successful!
 // suppressed
 forgetest!(shielded_literal_warnings_emitted_in_src, |prj, cmd| {
     // Skip if ssolc is not installed
-    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
-        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+    if std::process::Command::new("ssolc")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_err()
+    {
+        eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
 
@@ -1397,8 +1403,14 @@ contract Caller {
 // but still emits constructor/new-expr warnings (CREATE always leaks, even in tests)
 forgetest!(shielded_literal_warnings_suppressed_in_test, |prj, cmd| {
     // Skip if ssolc is not installed
-    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
-        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+    if std::process::Command::new("ssolc")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_err()
+    {
+        eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
 
@@ -1473,8 +1485,14 @@ contract CallerTest {
 // test that seismic-compilers suppresses ext-call shielded warnings in script/ files
 forgetest!(shielded_literal_warnings_suppressed_in_script, |prj, cmd| {
     // Skip if ssolc is not installed
-    if !std::path::Path::new("/usr/local/bin/ssolc").exists() {
-        eprintln!("skipping test: ssolc not found at /usr/local/bin/ssolc");
+    if std::process::Command::new("ssolc")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_err()
+    {
+        eprintln!("skipping test: ssolc not found in PATH");
         return;
     }
 

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -285,7 +285,9 @@ pub fn initialize(target: &Path) {
 
             cmd.args(["init", "--force"]).assert_success();
             prj.write_config(Config {
-                solc: Some(foundry_config::SolcReq::Version(SOLC_VERSION.parse().unwrap())),
+                // TODO: set to SolcReq::Version when ssolc supports version selection
+                // (see https://github.com/SeismicSystems/seismic-foundry/issues/186)
+                solc: None,
                 evm_version: foundry_compilers::artifacts::EvmVersion::Mercury,
                 ..Default::default()
             });


### PR DESCRIPTION
## Summary
- Replace hardcoded `/usr/local/bin/ssolc` (Linux) / `C:\Program Files\Seismic\bin\ssolc.exe` (Windows) with PATH lookup via `Command::new("ssolc")`
- When `seismic = true` and no `solc` is configured in foundry.toml, automatically find `ssolc` from PATH (previously fell through to upstream solc auto-detect)
- Update test skip guards to check PATH instead of hardcoded path

## Test plan
- [ ] CI passes (existing ssolc tests use PATH lookup now)
- [ ] `sforge build` works when `ssolc` is in PATH but not at `/usr/local/bin/ssolc`
- [ ] Error message is clear when `ssolc` is not installed