### PR TITLE
feat(config): error when via_ir=true without unsafe_via_ir in seismic mode

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -214,7 +214,9 @@ pub trait LoadConfig {
 
     /// Same as [`LoadConfig::load_config`] but does not emit warnings.
     fn load_config_no_warnings(&self) -> Result<Config, ExtractConfigError> {
-        self.load_config_unsanitized_no_warnings().map(Config::sanitized)
+        let config = self.load_config_unsanitized_no_warnings().map(Config::sanitized)?;
+        config.validate_seismic_settings().map_err(|e| ExtractConfigError::from_msg(e))?;
+        Ok(config)
     }
 
     /// Load [`Config`] but do not sanitize. See [`Config::sanitized`] for more information.
@@ -238,6 +240,8 @@ pub trait LoadConfig {
 
         let mut evm_opts = figment.extract::<EvmOpts>().map_err(ExtractConfigError::new)?;
         let config = Config::from_provider(figment)?.sanitized();
+
+        config.validate_seismic_settings()?;
 
         // update the fork url if it was an alias
         if let Some(fork_url) = config.get_rpc_url() {

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -16,6 +16,11 @@ impl ExtractConfigError {
     pub fn new(error: figment::Error) -> Self {
         Self { error }
     }
+
+    /// Creates an ExtractConfigError from a generic error message.
+    pub fn from_msg(msg: impl fmt::Display) -> Self {
+        Self { error: msg.to_string().into() }
+    }
 }
 
 impl fmt::Display for ExtractConfigError {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -934,6 +934,22 @@ impl Config {
         }
     }
 
+    /// Validates seismic-specific config invariants. Call this at CLI entry points
+    /// (not during internal config loading like nested remappings).
+    pub fn validate_seismic_settings(&self) -> eyre::Result<()> {
+        // ssolc requires `--unsafe-via-ir` alongside `--via-ir`.
+        // The via-ir pipeline is unstable in ssolc — require explicit opt-in.
+        if self.seismic && self.via_ir && !self.unsafe_via_ir {
+            eyre::bail!(
+                "`via_ir = true` requires `unsafe_via_ir = true` when using ssolc.\n\
+                 The via-ir pipeline is an unstable/experimental feature in ssolc.\n\
+                 To opt in, add `unsafe_via_ir = true` to your foundry.toml or pass \
+                 `--unsafe-via-ir` on the command line."
+            );
+        }
+        Ok(())
+    }
+
     /// Cleans up any duplicate `Remapping` and sorts them
     ///
     /// On windows this will convert any `\` in the remapping path into a `/`
@@ -6280,5 +6296,33 @@ mod tests {
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn test_validate_seismic_via_ir_with_unsafe_via_ir_ok() {
+        let config = Config { via_ir: true, unsafe_via_ir: true, ..Default::default() };
+        config.validate_seismic_settings().unwrap();
+    }
+
+    #[test]
+    fn test_validate_seismic_via_ir_without_unsafe_via_ir_errors() {
+        let config = Config { via_ir: true, unsafe_via_ir: false, ..Default::default() };
+        let err = config.validate_seismic_settings().unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe_via_ir"),
+            "error should mention unsafe_via_ir: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_non_seismic_via_ir_without_unsafe_via_ir_ok() {
+        let config = Config {
+            seismic: false,
+            evm_version: EvmVersion::Paris,
+            via_ir: true,
+            unsafe_via_ir: false,
+            ..Default::default()
+        };
+        config.validate_seismic_settings().unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- When `seismic = true` and `via_ir = true`, require explicit `unsafe_via_ir = true` opt-in
- Emits a clear error message explaining the via-ir pipeline is unstable/experimental in ssolc
- Users can set `unsafe_via_ir = true` in `foundry.toml` or pass `--unsafe-via-ir` on the CLI

## Test plan
- [x] `test_seismic_via_ir_with_unsafe_via_ir_ok` — seismic + via_ir + unsafe_via_ir proceeds normally
- [x] `test_non_seismic_via_ir_without_unsafe_via_ir_ok` — non-seismic configs unaffected
- [x] `cargo build --bin sforge` compiles cleanly