### PR TITLE
feat(config): wire SeismicConfig warning suppression through config and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=c782f58fc3998b00f4d7f95c46683829cef511ea#c782f58fc3998b00f4d7f95c46683829cef511ea"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?branch=cdai__seismic-warning-configs#1e6c5ede37d327f03ff945c09ee35778646f92d9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=c782f58fc3998b00f4d7f95c46683829cef511ea#c782f58fc3998b00f4d7f95c46683829cef511ea"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?branch=cdai__seismic-warning-configs#1e6c5ede37d327f03ff945c09ee35778646f92d9"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -4722,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=c782f58fc3998b00f4d7f95c46683829cef511ea#c782f58fc3998b00f4d7f95c46683829cef511ea"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?branch=cdai__seismic-warning-configs#1e6c5ede37d327f03ff945c09ee35778646f92d9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4744,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=c782f58fc3998b00f4d7f95c46683829cef511ea#c782f58fc3998b00f4d7f95c46683829cef511ea"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?branch=cdai__seismic-warning-configs#1e6c5ede37d327f03ff945c09ee35778646f92d9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.19.1"
-source = "git+https://github.com/SeismicSystems/seismic-compilers.git?rev=c782f58fc3998b00f4d7f95c46683829cef511ea#c782f58fc3998b00f4d7f95c46683829cef511ea"
+source = "git+https://github.com/SeismicSystems/seismic-compilers.git?branch=cdai__seismic-warning-configs#1e6c5ede37d327f03ff945c09ee35778646f92d9"
 dependencies = [
  "alloy-primitives",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,10 +412,10 @@ alloy-op-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev 
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "039d51496b9b9a0cb4fea6d606e472211b462073" }
 
 # foundry
-foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
-foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
-foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "c782f58fc3998b00f4d7f95c46683829cef511ea" }
+foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
+foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
+foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
 
 foundry-fork-db = { git = "https://github.com/SeismicSystems/seismic-foundry-fork-db.git", rev = "e5fb1f8838b517dbaaccc08a8af6767fe2e70c4e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,6 +412,7 @@ alloy-op-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev 
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "039d51496b9b9a0cb4fea6d606e472211b462073" }
 
 # foundry
+# TODO: update to rev pin once seismic-compilers PR #22 is merged
 foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
 foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
 foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,11 +412,10 @@ alloy-op-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev 
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "039d51496b9b9a0cb4fea6d606e472211b462073" }
 
 # foundry
-# TODO: update to rev pin once seismic-compilers PR #22 is merged
-foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
-foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
-foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
-foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
-foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", branch = "cdai__seismic-warning-configs" }
+foundry-compilers = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "97c0bb824a434fae8b2082474e682e5907a8ba20" }
+foundry-compilers-artifacts = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "97c0bb824a434fae8b2082474e682e5907a8ba20" }
+foundry-compilers-artifacts-solc = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "97c0bb824a434fae8b2082474e682e5907a8ba20" }
+foundry-compilers-artifacts-vyper = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "97c0bb824a434fae8b2082474e682e5907a8ba20" }
+foundry-compilers-core = { git = "https://github.com/SeismicSystems/seismic-compilers.git", rev = "97c0bb824a434fae8b2082474e682e5907a8ba20" }
 
 foundry-fork-db = { git = "https://github.com/SeismicSystems/seismic-foundry-fork-db.git", rev = "e5fb1f8838b517dbaaccc08a8af6767fe2e70c4e" }

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -134,6 +134,18 @@ pub struct BuildOpts {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_info_path: Option<PathBuf>,
 
+    /// Suppress all seismic/ssolc warnings (codes >= 10000).
+    #[arg(long, help_heading = "Compiler options")]
+    #[serde(skip)]
+    pub no_seismic_warnings: bool,
+
+    /// Show seismic warnings even in test files (*.t.sol).
+    ///
+    /// By default, seismic warnings are suppressed in test files.
+    #[arg(long, help_heading = "Compiler options")]
+    #[serde(skip)]
+    pub seismic_warnings_in_tests: bool,
+
     /// Skip building files whose names contain the given filter.
     ///
     /// `test` and `script` are aliases for `.t.sol` and `.s.sol`.
@@ -260,6 +272,14 @@ impl Provider for BuildOpts {
 
         if self.build_info {
             dict.insert("build_info".to_string(), self.build_info.into());
+        }
+
+        if self.no_seismic_warnings {
+            dict.insert("no_seismic_warnings".to_string(), true.into());
+        }
+
+        if self.seismic_warnings_in_tests {
+            dict.insert("seismic_warnings_in_tests".to_string(), true.into());
         }
 
         if self.compiler.ast {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -19,7 +19,7 @@ use figment::{
 use filter::GlobMatcher;
 use foundry_compilers::{
     ArtifactOutput, ConfigurableArtifacts, Graph, Project, ProjectPathsConfig,
-    RestrictionsWithVersion, VyperLanguage,
+    RestrictionsWithVersion, SeismicConfig, VyperLanguage,
     artifacts::{
         BytecodeHash, DebuggingSettings, EvmVersion, Libraries, ModelCheckerSettings,
         ModelCheckerTarget, Optimizer, OptimizerDetails, RevertStrings, Settings, SettingsMetadata,
@@ -547,6 +547,19 @@ pub struct Config {
     /// Also should we just rename this to `use_ssolc` instead of seismic, which is a bit confusing
     /// because it looks like it might also be used to configure execution (tests, anvil, etc).
     pub seismic: bool,
+
+    /// Suppress ALL seismic/ssolc warnings (codes >= 10000) globally.
+    ///
+    /// When set to true, no seismic-specific warnings will be emitted.
+    #[serde(default)]
+    pub no_seismic_warnings: bool,
+
+    /// Show seismic warnings even in test files.
+    ///
+    /// By default, seismic warnings (codes >= 10000) are suppressed in test files (*.t.sol).
+    /// Set this to true to see them.
+    #[serde(default)]
+    pub seismic_warnings_in_tests: bool,
 
     /// Warnings gathered when loading the Config. See [`WarningsProvider`] for more information.
     #[serde(rename = "__warnings", default, skip_serializing)]
@@ -1084,7 +1097,11 @@ impl Config {
             .set_offline(self.offline)
             .set_cached(cached)
             .set_build_info(!no_artifacts && self.build_info)
-            .set_no_artifacts(no_artifacts);
+            .set_no_artifacts(no_artifacts)
+            .set_seismic_config(SeismicConfig {
+                no_seismic_warnings: self.no_seismic_warnings,
+                seismic_warnings_in_tests: self.seismic_warnings_in_tests,
+            });
 
         if !self.skip.is_empty() {
             let filter = SkipBuildFilters::new(self.skip.clone(), self.root.clone());
@@ -1656,8 +1673,14 @@ impl Config {
             settings = settings.with_ast();
         }
 
-        let cli_settings =
-            CliSettings { extra_args: self.extra_args.clone(), ..Default::default() };
+        let cli_settings = CliSettings {
+            extra_args: self.extra_args.clone(),
+            seismic_cfg: SeismicConfig {
+                no_seismic_warnings: self.no_seismic_warnings,
+                seismic_warnings_in_tests: self.seismic_warnings_in_tests,
+            },
+            ..Default::default()
+        };
 
         Ok(SolcSettings { settings, cli_settings })
     }
@@ -2527,6 +2550,8 @@ impl Default for Config {
             additional_compiler_profiles: Default::default(),
             compilation_restrictions: Default::default(),
             seismic: true,
+            no_seismic_warnings: false,
+            seismic_warnings_in_tests: false,
             script_execution_protection: true,
             _non_exhaustive: (),
         }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1553,6 +1553,7 @@ contract DeployScript {
 });
 
 // test that --no-seismic-warnings suppresses ALL seismic warnings (codes >= 10000) even in src/
+// and that the build summary reflects the suppression
 forgetest!(no_seismic_warnings_flag_suppresses_all, |prj, cmd| {
     if !has_ssolc() {
         eprintln!("skipping test: ssolc not found in PATH");
@@ -1599,15 +1600,20 @@ contract Caller {
 "#,
     );
 
-    // Without the flag: warnings should appear
+    // Without the flag: seismic warnings should appear and build should report "with warnings"
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Warning (10"),
         "expected seismic warnings without --no-seismic-warnings flag:\n{stdout}"
     );
+    assert!(
+        stdout.contains("with warnings"),
+        "build summary should say 'with warnings' when seismic warnings are present:\n{stdout}"
+    );
 
-    // With --no-seismic-warnings: ALL seismic warnings should be suppressed
+    // With --no-seismic-warnings: ALL seismic warnings should be suppressed and build should be
+    // clean
     let output2 = cmd
         .forge_fuse()
         .args(["build", "--force", "--no-seismic-warnings"])
@@ -1619,9 +1625,68 @@ contract Caller {
         !stdout2.contains("Warning (10"),
         "no seismic warnings should appear with --no-seismic-warnings flag:\n{stdout2}"
     );
+    assert!(
+        stdout2.contains("Compiler run successful!")
+            && !stdout2.contains("Compiler run successful with warnings"),
+        "build should report clean success with --no-seismic-warnings:\n{stdout2}"
+    );
+});
+
+// test that --no-seismic-warnings only suppresses seismic warnings (>= 10000), not standard
+// Solidity warnings
+forgetest!(no_seismic_warnings_preserves_standard_warnings, |prj, cmd| {
+    if !has_ssolc() {
+        eprintln!("skipping test: ssolc not found in PATH");
+        return;
+    }
+
+    prj.update_config(|config| {
+        config.seismic = true;
+        // Only suppress SPDX and pre-release — leave other standard warnings enabled
+        config.ignored_error_codes =
+            vec![SolidityErrorCode::SpdxLicenseNotProvided, SolidityErrorCode::Other(3805)];
+    });
+
+    // Contract with both seismic warnings AND a standard Solidity warning (unused variable)
+    prj.add_raw_source(
+        "src/Mixed.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Mixed {
+    suint256 internal val;
+
+    constructor(suint256 _v) { val = _v; }
+
+    function doSomething() external view returns (uint256) {
+        uint256 unused = 42;
+        return uint256(val);
+    }
+}
+"#,
+    );
+
+    // With --no-seismic-warnings: seismic warnings gone, but standard warnings remain
+    let output = cmd
+        .args(["build", "--force", "--no-seismic-warnings"])
+        .assert_success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Warning (10"),
+        "seismic warnings should be suppressed with --no-seismic-warnings:\n{stdout}"
+    );
+    // Standard Solidity unused-variable warning (2072) should still appear
+    assert!(
+        stdout.contains("Warning"),
+        "standard Solidity warnings should still appear with --no-seismic-warnings:\n{stdout}"
+    );
 });
 
 // test that --seismic-warnings-in-tests shows warnings that are normally suppressed in test files
+// and that the build output changes accordingly
 forgetest!(seismic_warnings_in_tests_flag_shows_suppressed, |prj, cmd| {
     if !has_ssolc() {
         eprintln!("skipping test: ssolc not found in PATH");
@@ -1630,8 +1695,13 @@ forgetest!(seismic_warnings_in_tests_flag_shows_suppressed, |prj, cmd| {
 
     prj.update_config(|config| {
         config.seismic = true;
-        config.ignored_error_codes =
-            vec![SolidityErrorCode::SpdxLicenseNotProvided, SolidityErrorCode::Other(3805)];
+        config.ignored_error_codes = vec![
+            SolidityErrorCode::SpdxLicenseNotProvided,
+            SolidityErrorCode::Other(3805),
+            // Suppress constructor/new-expr warnings so we can isolate 10402 behavior
+            SolidityErrorCode::ShieldedConstructorParam,
+            SolidityErrorCode::ShieldedLiteralNewExprInt,
+        ];
     });
 
     prj.add_raw_source(
@@ -1669,15 +1739,19 @@ contract CallerTest {
 "#,
     );
 
-    // Without the flag: 10402 should be suppressed in test files
+    // Without the flag: 10402 should be suppressed in test files, build should be clean
     let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stdout.contains("Warning (10402)"),
         "10402 should be suppressed in test files by default:\n{stdout}"
     );
+    assert!(
+        !stdout.contains("with warnings"),
+        "build should be clean when test-file warnings are suppressed:\n{stdout}"
+    );
 
-    // With --seismic-warnings-in-tests: 10402 should now appear
+    // With --seismic-warnings-in-tests: 10402 should now appear and build should report warnings
     let output2 = cmd
         .forge_fuse()
         .args(["build", "--force", "--seismic-warnings-in-tests"])
@@ -1688,6 +1762,10 @@ contract CallerTest {
     assert!(
         stdout2.contains("Warning (10402)"),
         "10402 should appear with --seismic-warnings-in-tests flag:\n{stdout2}"
+    );
+    assert!(
+        stdout2.contains("with warnings"),
+        "build should report 'with warnings' when test-file warnings are un-suppressed:\n{stdout2}"
     );
 });
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1612,8 +1612,7 @@ contract Caller {
         "build summary should say 'with warnings' when seismic warnings are present:\n{stdout}"
     );
 
-    // With --no-seismic-warnings: ALL seismic warnings should be suppressed and build should be
-    // clean
+    // With --no-seismic-warnings: all seismic warnings suppressed, build should be clean
     let output2 = cmd
         .forge_fuse()
         .args(["build", "--force", "--no-seismic-warnings"])

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1552,6 +1552,145 @@ contract DeployScript {
     );
 });
 
+// test that --no-seismic-warnings suppresses ALL seismic warnings (codes >= 10000) even in src/
+forgetest!(no_seismic_warnings_flag_suppresses_all, |prj, cmd| {
+    if !has_ssolc() {
+        eprintln!("skipping test: ssolc not found in PATH");
+        return;
+    }
+
+    prj.update_config(|config| {
+        config.seismic = true;
+        config.ignored_error_codes =
+            vec![SolidityErrorCode::SpdxLicenseNotProvided, SolidityErrorCode::Other(3805)];
+    });
+
+    prj.add_raw_source(
+        "src/Receiver.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Receiver {
+    suint256 internal val;
+    constructor(suint256 _v) { val = _v; }
+    function setVal(suint256 _v) external { val = _v; }
+}
+"#,
+    );
+
+    prj.add_raw_source(
+        "src/Caller.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Receiver} from "./Receiver.sol";
+
+contract Caller {
+    Receiver public r;
+    constructor() {
+        r = new Receiver(suint256(42));
+    }
+    function callWithLiteral() external {
+        r.setVal(suint256(100));
+    }
+}
+"#,
+    );
+
+    // Without the flag: warnings should appear
+    let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Warning (10"),
+        "expected seismic warnings without --no-seismic-warnings flag:\n{stdout}"
+    );
+
+    // With --no-seismic-warnings: ALL seismic warnings should be suppressed
+    let output2 = cmd
+        .forge_fuse()
+        .args(["build", "--force", "--no-seismic-warnings"])
+        .assert_success()
+        .get_output()
+        .clone();
+    let stdout2 = String::from_utf8_lossy(&output2.stdout);
+    assert!(
+        !stdout2.contains("Warning (10"),
+        "no seismic warnings should appear with --no-seismic-warnings flag:\n{stdout2}"
+    );
+});
+
+// test that --seismic-warnings-in-tests shows warnings that are normally suppressed in test files
+forgetest!(seismic_warnings_in_tests_flag_shows_suppressed, |prj, cmd| {
+    if !has_ssolc() {
+        eprintln!("skipping test: ssolc not found in PATH");
+        return;
+    }
+
+    prj.update_config(|config| {
+        config.seismic = true;
+        config.ignored_error_codes =
+            vec![SolidityErrorCode::SpdxLicenseNotProvided, SolidityErrorCode::Other(3805)];
+    });
+
+    prj.add_raw_source(
+        "src/Receiver.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Receiver {
+    suint256 internal val;
+    constructor(suint256 _v) { val = _v; }
+    function setVal(suint256 _v) external { val = _v; }
+}
+"#,
+    );
+
+    prj.add_raw_source(
+        "test/Caller.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Receiver} from "../src/Receiver.sol";
+
+contract CallerTest {
+    Receiver public r;
+    constructor() {
+        r = new Receiver(suint256(42));
+    }
+    function testCallWithLiteral() external {
+        // 10402 (ext-call) — normally suppressed in test files
+        r.setVal(suint256(100));
+    }
+}
+"#,
+    );
+
+    // Without the flag: 10402 should be suppressed in test files
+    let output = cmd.args(["build", "--force"]).assert_success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Warning (10402)"),
+        "10402 should be suppressed in test files by default:\n{stdout}"
+    );
+
+    // With --seismic-warnings-in-tests: 10402 should now appear
+    let output2 = cmd
+        .forge_fuse()
+        .args(["build", "--force", "--seismic-warnings-in-tests"])
+        .assert_success()
+        .get_output()
+        .clone();
+    let stdout2 = String::from_utf8_lossy(&output2.stdout);
+    assert!(
+        stdout2.contains("Warning (10402)"),
+        "10402 should appear with --seismic-warnings-in-tests flag:\n{stdout2}"
+    );
+});
+
 // test that a failing `forge build` does not impact followup builds
 forgetest!(can_build_after_failure, |prj, cmd| {
     prj.insert_ds_test();

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -179,6 +179,8 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         script_execution_protection: true,
         _non_exhaustive: (),
         seismic: true,
+        no_seismic_warnings: false,
+        seismic_warnings_in_tests: true,
     };
     prj.write_config(input.clone());
     let config = cmd.config();

--- a/crates/verify/src/etherscan/flatten.rs
+++ b/crates/verify/src/etherscan/flatten.rs
@@ -91,7 +91,7 @@ impl EtherscanFlattenedSource {
         if out.errors.iter().any(|e| e.is_error()) {
             let mut o = AggregatedCompilerOutput::<SolcCompiler>::default();
             o.extend(version, RawBuildInfo::new(&input, &out, false)?, "default", out);
-            let diags = o.diagnostics(&[], &[], Default::default());
+            let diags = o.diagnostics(&[], &[], Default::default(), Default::default());
 
             eyre::bail!(
                 "\


### PR DESCRIPTION
## Summary
- Bumps seismic-compilers dependency to `cdai__seismic-warning-configs` branch, which adds `SeismicConfig { no_seismic_warnings, seismic_warnings_in_tests }` and `CliSettings.seismic_cfg`
- Adds `no_seismic_warnings` and `seismic_warnings_in_tests` fields to `Config` in `crates/config/src/lib.rs`, with serde support and `false` defaults
- Adds `--no-seismic-warnings` and `--seismic-warnings-in-tests` CLI flags to `BuildOpts`, available on all sforge commands (build, test, script, etc.)
- Threads config values into both `CliSettings.seismic_cfg` (for solc settings) and `Project::builder().set_seismic_config()` (for project-level warning filtering)
- Fixes `diagnostics()` call in `forge-verify` to pass the new `SeismicConfig` argument

## Usage

In `foundry.toml`:
```toml
no_seismic_warnings = true        # suppress ALL ssolc warnings (codes >= 10000)
seismic_warnings_in_tests = true  # show ssolc warnings even in *.t.sol files
```

Via CLI:
```bash
sforge build --no-seismic-warnings
sforge test --seismic-warnings-in-tests
```

## Test plan
- [x] `cargo build --bin sforge` compiles successfully
- [x] `cargo +nightly fmt --all --check` passes
- [ ] CI: `cargo nextest run test_seismic_` passes
- [ ] Manually verify `--no-seismic-warnings` flag appears in `sforge build --help`
- [ ] Manually verify `no_seismic_warnings = true` in foundry.toml suppresses ssolc warnings