### PR TITLE
feat: revert sfoundryup to foundryup behavior

### DIFF
--- a/foundryup/README.md
+++ b/foundryup/README.md
@@ -1,52 +1,91 @@
 # `sfoundryup`
 
-Install and update the Seismic Foundry suite of developer tools with ease.
+Update or revert to a specific Seismic Foundry version with ease.
 
-### Installing
+`sfoundryup` supports installing and managing multiple versions.
 
-Run the following command to install `sfoundryup`:
+## Installing
 
-```bash
-curl -L -H "Accept: application/vnd.github.v3.raw" \
-     "https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install" | bash
-```
-
-Now, either open a new terminal or reload your shell configuration to start using sfoundryup:
-
-For `bash` users:
-
-```bash
-source ~/.bashrc
-```
-
-For `zsh` users:
-
-```bash
-source ~/.zshrc
-```
-
-For `fish` users:
-
-```bash
-source ~/.config/fish/config.fish
-```
-
-For `ash` users:
-
-```bash
-source ~/.profile
+```sh
+curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash
 ```
 
 ## Usage
 
-### Install Seismic Foundry:
+To install the latest **stable** version (default):
 
-Run the following in your terminal to install the Seismic Foundry suite of developer tools:
-
-```bash
+```sh
 sfoundryup
 ```
 
+To install the latest **nightly**:
+
+```sh
+sfoundryup --install nightly
 ```
-**Tip**: All flags have a single-character shorthand equivalent! You can use -v instead of --version, etc.
+
+To **install** a specific **version**:
+
+```sh
+sfoundryup --install v0.1.0
+```
+
+To **list** all **versions** installed:
+
+```sh
+sfoundryup --list
+```
+
+To switch between different versions and **use**:
+
+```sh
+sfoundryup --use nightly
+```
+
+To install a specific **branch** (in this case the `seismic` branch's latest commit):
+
+```sh
+sfoundryup --branch seismic
+```
+
+To install from a **specific Pull Request**:
+
+```sh
+sfoundryup --pr 190
+```
+
+To install from a **specific commit**:
+
+```sh
+sfoundryup -C 94bfdb2
+```
+
+To install a local directory or repository (e.g. one located at `~/git/seismic-foundry`, assuming you're in the home directory)
+
+#### Note: --branch, --repo, and --version flags are ignored during local installations.
+
+```sh
+sfoundryup --path ./git/seismic-foundry
+```
+
+---
+
+**Tip**: All flags have a single character shorthand equivalent! You can use `-i` instead of `--install`, etc.
+
+---
+
+## Uninstalling
+
+Seismic Foundry contains everything in a `.seismic` directory, usually located in `/home/<user>/.seismic/` on Linux and `/Users/<user>/.seismic/` on MacOS where `<user>` is your username.
+
+To uninstall Seismic Foundry remove the `.seismic` directory.
+
+#### Warning ⚠️: .seismic directory can contain keystores. Make sure to backup any keystores you want to keep.
+
+Remove sfoundryup from PATH:
+
+- Optionally sfoundryup can be removed by editing shell configuration file (`.bashrc`, `.zshrc`, etc.). To do so remove the line that adds sfoundryup to PATH:
+
+```sh
+export PATH="$PATH:/home/user/.seismic/bin"
 ```

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -16,7 +16,7 @@ FOUNDRY_BIN_PATH="$FOUNDRY_BIN_DIR/sfoundryup"
 FOUNDRYUP_JOBS=""
 FOUNDRYUP_IGNORE_VERIFICATION=false
 
-BINS=(sforge scast sanvil schisel)
+BINS=(sforge scast sanvil)
 HASH_NAMES=()
 HASH_VALUES=()
 
@@ -154,7 +154,7 @@ main() {
       else
         ARCHITECTURE="amd64" # Intel.
       fi
-    elif [ "${ARCHITECTURE}" = "arm64" ] ||[ "${ARCHITECTURE}" = "aarch64" ] ; then
+    elif [ "${ARCHITECTURE}" = "arm64" ] || [ "${ARCHITECTURE}" = "aarch64" ] ; then
       ARCHITECTURE="arm64" # Arm.
     else
       ARCHITECTURE="amd64" # Amd.
@@ -171,7 +171,7 @@ main() {
     # If `--force` is set, skip the SHA verification.
     if [ "$FOUNDRYUP_IGNORE_VERIFICATION" = false ]; then
       # Check if the version is already installed by downloading the attestation file.
-      say "checking if sforge, scast, sanvil, and schisel for $FOUNDRYUP_TAG version are already installed"
+      say "checking if sforge, scast, and sanvil for $FOUNDRYUP_TAG version are already installed"
 
       # Create a temporary directory to store the attestation link and artifact.
       tmp_dir="$(mktemp -d 2>/dev/null || echo ".")"
@@ -262,13 +262,13 @@ main() {
     fi
 
     # Download and extract the binaries archive
-    say "downloading sforge, scast, sanvil, and schisel for $FOUNDRYUP_TAG version"
+    say "downloading sforge, scast, and sanvil for $FOUNDRYUP_TAG version"
     tmp="$(mktemp -d 2>/dev/null || echo ".")/sfoundry.tar.gz"
     ensure download "$BIN_ARCHIVE_URL" "$tmp"
     # Make sure it's a valid tar archive.
-    ensure tar tf $tmp 1> /dev/null
+    ensure tar tf "$tmp" 1> /dev/null
     ensure mkdir -p "$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_TAG"
-    ensure tar -C "$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_TAG" -xvf $tmp
+    ensure tar -C "$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_TAG" -xvf "$tmp"
     rm -f "$tmp"
 
     # Optionally download the manuals
@@ -419,7 +419,7 @@ install_ssolc() {
       INSTALL_DIR="/usr/local/bin"
       ;;
     *)
-      echo "Unsupported OS: $OS"
+      echo "Unsupported OS: $OS (only Linux and macOS are supported)"
       exit 1
       ;;
   esac

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -1,259 +1,763 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
-SEISMIC_DIR=${SEISMIC_DIR:-"$BASE_DIR/.seismic"}
-SEISMIC_BIN_DIR="$SEISMIC_DIR/bin"
-SEISMIC_MAN_DIR="$SEISMIC_DIR/share/man/man1"
+# NOTE: if you make modifications to this script, please increment the version number.
+# WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
+# SEISMIC NOTE: until we stabilize, please do not bump major version to 1.
+FOUNDRYUP_INSTALLER_VERSION="0.1.0"
 
-SEISMICUP_JOBS=""
-BINS=(sanvil sforge scast)
+BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
+FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.seismic"}
+FOUNDRY_VERSIONS_DIR="$FOUNDRY_DIR/versions"
+FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
+FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
+FOUNDRY_BIN_URL="https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/foundryup"
+FOUNDRY_BIN_PATH="$FOUNDRY_BIN_DIR/sfoundryup"
+FOUNDRYUP_JOBS=""
+FOUNDRYUP_IGNORE_VERIFICATION=false
+
+BINS=(sforge scast sanvil schisel)
+HASH_NAMES=()
+HASH_VALUES=()
 
 export RUSTFLAGS="${RUSTFLAGS:--C target-cpu=native}"
 
 main() {
- while [[ -n $1 ]]; do
-   case $1 in
-     --)               shift; break;;
-     -v|--version)     shift; SEISMICUP_VERSION=$1;;
-     -p|--path)        shift; SEISMICUP_LOCAL_REPO=$1;;
-     -j|--jobs)        shift; SEISMICUP_JOBS=$1;;
-     -h|--help)
-       usage
-       exit 0
-       ;;
-     *)
-       warn "unknown option: $1"
-       usage
-       exit 1
-       ;;
-   esac
-   shift
- done
+  need_cmd git
+  need_cmd curl
+  need_cmd jq
 
- need_cmd git
- need_cmd curl
- need_cmd jq
+  while [[ -n $1 ]]; do
+    case $1 in
+      --)               shift; break;;
 
- CARGO_BUILD_ARGS=(--release)
+      -v|--version)     shift; version;;
+      -U|--update)      shift; update;;
+      -r|--repo)        shift; FOUNDRYUP_REPO=$1;;
+      -b|--branch)      shift; FOUNDRYUP_BRANCH=$1;;
+      -i|--install)     shift; FOUNDRYUP_VERSION=$1;;
+      -l|--list)        shift; list;;
+      -u|--use)         shift; FOUNDRYUP_VERSION=$1; use;;
+      -p|--path)        shift; FOUNDRYUP_LOCAL_REPO=$1;;
+      -P|--pr)          shift; FOUNDRYUP_PR=$1;;
+      -C|--commit)      shift; FOUNDRYUP_COMMIT=$1;;
+      -j|--jobs)        shift; FOUNDRYUP_JOBS=$1;;
+      -f|--force)       FOUNDRYUP_IGNORE_VERIFICATION=true;;
+      --arch)           shift; FOUNDRYUP_ARCH=$1;;
+      --platform)       shift; FOUNDRYUP_PLATFORM=$1;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        warn "unknown option: $1"
+        usage
+        exit 1
+    esac; shift
+  done
 
- if [ -n "$SEISMICUP_JOBS" ]; then
-   CARGO_BUILD_ARGS+=(--jobs "$SEISMICUP_JOBS")
- fi
+  CARGO_BUILD_ARGS=(--release)
 
- banner
- install_ssolc
+  if [ -n "$FOUNDRYUP_JOBS" ]; then
+    CARGO_BUILD_ARGS+=(--jobs "$FOUNDRYUP_JOBS")
+  fi
 
- if [[ -n "$SEISMICUP_LOCAL_REPO" ]]; then
-   install_from_local_repo
- else
-   install_from_remote_repo
- fi
+  # Print the banner after successfully parsing args
+  banner
+
+  # Check if the foundryup installer is up to date, warn the user if not
+  check_installer_up_to_date
+
+  if [ -n "$FOUNDRYUP_PR" ]; then
+    if [ -z "$FOUNDRYUP_BRANCH" ]; then
+      FOUNDRYUP_BRANCH="refs/pull/$FOUNDRYUP_PR/head"
+    else
+      err "can't use --pr and --branch at the same time"
+    fi
+  fi
+
+  check_bins_in_use
+
+  # Installs foundry from a local repository if --path parameter is provided
+  if [[ -n "$FOUNDRYUP_LOCAL_REPO" ]]; then
+    need_cmd cargo
+
+    # Ignore branches/versions as we do not want to modify local git state
+    if [ -n "$FOUNDRYUP_REPO" ] || [ -n "$FOUNDRYUP_BRANCH" ] || [ -n "$FOUNDRYUP_VERSION" ]; then
+      warn "--branch, --install, --use, and --repo arguments are ignored during local install"
+    fi
+
+    # Enter local repo and build
+    say "installing from $FOUNDRYUP_LOCAL_REPO"
+    cd "$FOUNDRYUP_LOCAL_REPO"
+    ensure cargo build --bins "${CARGO_BUILD_ARGS[@]}"
+
+    for bin in "${BINS[@]}"; do
+      # Remove prior installations if they exist
+      rm -f "$FOUNDRY_BIN_DIR/$bin"
+      # Symlink from local repo binaries to bin dir
+      ensure ln -s "$PWD/target/release/$bin" "$FOUNDRY_BIN_DIR/$bin"
+    done
+
+    say "done"
+    exit 0
+  fi
+
+  FOUNDRYUP_REPO=${FOUNDRYUP_REPO:-SeismicSystems/seismic-foundry}
+
+  # Install by downloading binaries
+  if [[ "$FOUNDRYUP_REPO" == "SeismicSystems/seismic-foundry" && -z "$FOUNDRYUP_BRANCH" && -z "$FOUNDRYUP_COMMIT" ]]; then
+    FOUNDRYUP_VERSION=${FOUNDRYUP_VERSION:-stable}
+    FOUNDRYUP_TAG=$FOUNDRYUP_VERSION
+
+    # Normalize versions (handle channels, versions without v prefix)
+    if [[ "$FOUNDRYUP_VERSION" == "stable" ]]; then
+      # Resolve 'stable' to the latest non-prerelease GitHub release tag.
+      # The /releases/latest endpoint returns the most recent non-prerelease, non-draft release.
+      FOUNDRYUP_TAG=$(curl -fsSL "https://api.github.com/repos/$FOUNDRYUP_REPO/releases/latest" | grep '"tag_name"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+      if [ -z "$FOUNDRYUP_TAG" ]; then
+        err "could not determine latest stable version. No stable release exists yet. Try 'sfoundryup -i nightly' instead."
+      fi
+      FOUNDRYUP_VERSION=$FOUNDRYUP_TAG
+    elif [[ "$FOUNDRYUP_VERSION" =~ ^nightly ]]; then
+      FOUNDRYUP_VERSION="nightly"
+    elif [[ "$FOUNDRYUP_VERSION" == [[:digit:]]* ]]; then
+      # Add v prefix
+      FOUNDRYUP_VERSION="v${FOUNDRYUP_VERSION}"
+      FOUNDRYUP_TAG="${FOUNDRYUP_VERSION}"
+    fi
+
+    say "installing sfoundry (version ${FOUNDRYUP_VERSION}, tag ${FOUNDRYUP_TAG})"
+
+    # Install ssolc before downloading sfoundry binaries
+    install_ssolc
+
+    uname_s=$(uname -s)
+    PLATFORM=$(tolower "${FOUNDRYUP_PLATFORM:-$uname_s}")
+    EXT="tar.gz"
+    case $PLATFORM in
+      linux) ;;
+      darwin|mac*)
+        PLATFORM="darwin"
+        ;;
+      *)
+        err "unsupported platform: $PLATFORM"
+        ;;
+    esac
+
+    uname_m=$(uname -m)
+    ARCHITECTURE=$(tolower "${FOUNDRYUP_ARCH:-$uname_m}")
+    if [ "${ARCHITECTURE}" = "x86_64" ]; then
+      # Redirect stderr to /dev/null to avoid printing errors if non Rosetta.
+      if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+        ARCHITECTURE="arm64" # Rosetta.
+      else
+        ARCHITECTURE="amd64" # Intel.
+      fi
+    elif [ "${ARCHITECTURE}" = "arm64" ] ||[ "${ARCHITECTURE}" = "aarch64" ] ; then
+      ARCHITECTURE="arm64" # Arm.
+    else
+      ARCHITECTURE="amd64" # Amd.
+    fi
+
+    # Compute the URL of the release tarball in the Foundry repository.
+    RELEASE_URL="https://github.com/${FOUNDRYUP_REPO}/releases/download/${FOUNDRYUP_TAG}/"
+    ATTESTATION_URL="${RELEASE_URL}sfoundry_${FOUNDRYUP_VERSION}_${PLATFORM}_${ARCHITECTURE}.attestation.txt"
+    BIN_ARCHIVE_URL="${RELEASE_URL}sfoundry_${FOUNDRYUP_VERSION}_${PLATFORM}_${ARCHITECTURE}.$EXT"
+    MAN_TARBALL_URL="${RELEASE_URL}sfoundry_man_${FOUNDRYUP_VERSION}.tar.gz"
+
+    ensure mkdir -p "$FOUNDRY_VERSIONS_DIR"
+
+    # If `--force` is set, skip the SHA verification.
+    if [ "$FOUNDRYUP_IGNORE_VERIFICATION" = false ]; then
+      # Check if the version is already installed by downloading the attestation file.
+      say "checking if sforge, scast, sanvil, and schisel for $FOUNDRYUP_TAG version are already installed"
+
+      # Create a temporary directory to store the attestation link and artifact.
+      tmp_dir="$(mktemp -d 2>/dev/null || echo ".")"
+      tmp="$tmp_dir/attestation.txt"
+      ensure download "$ATTESTATION_URL" "$tmp"
+
+      # Read the first line of the attestation file to get the artifact link.
+      # The first line should contain the link to the attestation artifact.
+      attestation_artifact_link="$(head -n1 "$tmp" | tr -d '\r')"
+      attestation_missing=false
+
+      # If the attestation artifact link is empty or the file contains 'Not Found',
+      # we consider the attestation missing and skip the SHA verification.
+      if [ -z "$attestation_artifact_link" ] || grep -q 'Not Found' "$tmp"; then
+        attestation_missing=true
+      fi
+
+      # Clean up the temporary attestation file.
+      rm -f "$tmp"
+
+      if $attestation_missing; then
+        say "no attestation found for this release, skipping SHA verification"
+      else
+        say "found attestation for $FOUNDRYUP_TAG version, downloading attestation artifact, checking..."
+
+        # Download the attestation artifact JSON file.
+        tmp="$tmp_dir/foundry-attestation.sigstore.json"
+        ensure download "${attestation_artifact_link}/download" "$tmp"
+
+        # Extract the payload from the JSON file.
+        payload_b64=$(awk '/"payload":/ {gsub(/[",]/, "", $2); print $2; exit}' "$tmp")
+        payload_json=$(printf '%s' "$payload_b64" | base64 -d 2>/dev/null || printf '%s' "$payload_b64" | base64 -D)
+
+
+        # Extract the names and hashes from the payload JSON.
+        # The payload is expected to be a JSON array of objects with "name" and "sha256" fields.
+        while read -r name_line && read -r sha_line; do
+          name=$(echo "$name_line" | sed -nE 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')
+          sha=$(echo "$sha_line"  | sed -nE 's/.*"sha256"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')
+          if [ -n "$name" ] && [ -n "$sha" ]; then
+            HASH_NAMES+=("$name")
+            HASH_VALUES+=("$sha")
+          fi
+        done < <(echo "$payload_json" | tr '{}' '\n' | grep -E '"name"|sha256')
+
+        # Clean up the temporary attestation artifact.
+        # The hashes are now stored in the HASHES associative array.
+        rm -f "$tmp"
+
+        # Check if the binaries are already installed and match the expected hashes.
+        # If they do, skip the download.
+        version_dir="$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_TAG"
+        all_match=true
+        for bin in "${BINS[@]}"; do
+          expected=""
+          for i in "${!HASH_NAMES[@]}"; do
+            if [ "${HASH_NAMES[$i]}" = "$bin" ] || [ "${HASH_NAMES[$i]}" = "$bin.exe" ]; then
+              expected="${HASH_VALUES[$i]}"
+              break
+            fi
+          done
+
+          path="$version_dir/$bin"
+
+          if [ -z "$expected" ] || [ ! -x "$path" ]; then
+            all_match=false
+            break
+          fi
+
+          actual=$(compute_sha256 "$path")
+          if [ "$actual" != "$expected" ]; then
+            all_match=false
+            break
+          fi
+        done
+
+        if $all_match; then
+          say "version $FOUNDRYUP_TAG already installed and verified, activating..."
+          FOUNDRYUP_VERSION=$FOUNDRYUP_TAG
+          use
+          say "done!"
+          exit 0
+        fi
+      fi
+
+      # If we reach here, we need to download the binaries.
+      say "binaries not found or do not match expected hashes, downloading new binaries"
+    fi
+
+    # Download and extract the binaries archive
+    say "downloading sforge, scast, sanvil, and schisel for $FOUNDRYUP_TAG version"
+    tmp="$(mktemp -d 2>/dev/null || echo ".")/sfoundry.tar.gz"
+    ensure download "$BIN_ARCHIVE_URL" "$tmp"
+    # Make sure it's a valid tar archive.
+    ensure tar tf $tmp 1> /dev/null
+    ensure mkdir -p "$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_TAG"
+    ensure tar -C "$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_TAG" -xvf $tmp
+    rm -f "$tmp"
+
+    # Optionally download the manuals
+    if check_cmd tar; then
+      say "downloading manpages"
+      mkdir -p "$FOUNDRY_MAN_DIR"
+      if ! download "$MAN_TARBALL_URL" | tar -xzC "$FOUNDRY_MAN_DIR"; then
+        warn "skipping manpage download: unavailable or invalid archive"
+      fi
+    else
+      say 'skipping manpage download: missing "tar"'
+    fi
+
+    if [ "$FOUNDRYUP_IGNORE_VERIFICATION" = true ]; then
+      say "skipped SHA verification for downloaded binaries due to --force flag"
+    else
+      # Verify the downloaded binaries against the attestation file.
+      # If the attestation file was not found or is empty, we skip the verification.
+      if $attestation_missing; then
+        say "no attestation found for these binaries, skipping SHA verification for downloaded binaries"
+      else
+        say "verifying downloaded binaries against the attestation file"
+
+        failed=false
+        for bin in "${BINS[@]}"; do
+          expected=""
+          for i in "${!HASH_NAMES[@]}"; do
+            if [ "${HASH_NAMES[$i]}" = "$bin" ] || [ "${HASH_NAMES[$i]}" = "$bin.exe" ]; then
+              expected="${HASH_VALUES[$i]}"
+              break
+            fi
+          done
+
+          path="$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_TAG/$bin"
+
+          if [ -z "$expected" ]; then
+            say "no expected hash for $bin"
+            failed=true
+            continue
+          fi
+
+          if [ ! -x "$path" ]; then
+            say "binary $bin not found at $path"
+            failed=true
+            continue
+          fi
+
+          actual=$(compute_sha256 "$path")
+          if [ "$actual" != "$expected" ]; then
+            say "$bin hash verification failed:"
+            say "  expected: $expected"
+            say "  actual:   $actual"
+            failed=true
+          else
+            say "$bin verified ✓"
+          fi
+        done
+
+        if $failed; then
+          err "one or more binaries failed post-installation verification"
+        fi
+      fi
+    fi
+
+    # Use newly installed version.
+    FOUNDRYUP_VERSION=$FOUNDRYUP_TAG
+    use
+
+    say "done!"
+
+  # Install by cloning the repo with the provided branch/tag
+  else
+    need_cmd cargo
+    FOUNDRYUP_BRANCH=${FOUNDRYUP_BRANCH:-seismic}
+    REPO_PATH="$FOUNDRY_DIR/$FOUNDRYUP_REPO"
+    AUTHOR="$(echo "$FOUNDRYUP_REPO" | cut -d'/' -f1 -)"
+
+    # If repo path does not exist, grab the author from the repo, make a directory in .seismic, cd to it and clone.
+    if [ ! -d "$REPO_PATH" ]; then
+      ensure mkdir -p "$FOUNDRY_DIR/$AUTHOR"
+      cd "$FOUNDRY_DIR/$AUTHOR"
+      ensure git clone "https://github.com/$FOUNDRYUP_REPO"
+    fi
+
+    # Force checkout, discarding any local changes
+    cd "$REPO_PATH"
+    ensure git fetch origin "${FOUNDRYUP_BRANCH}:remotes/origin/${FOUNDRYUP_BRANCH}"
+    ensure git checkout "origin/${FOUNDRYUP_BRANCH}"
+
+    # Create custom version based on the install method, e.g.:
+    # - SeismicSystems-commit-c22c4cc96b0535cd989ee94b79da1b19d236b8db
+    # - SeismicSystems-pr-1
+    # - SeismicSystems-branch-chore-bump-forge-std
+    if [ -n "$FOUNDRYUP_COMMIT" ]; then
+      # If set, checkout specific commit from branch
+      ensure git checkout "$FOUNDRYUP_COMMIT"
+      FOUNDRYUP_VERSION=$AUTHOR-commit-$FOUNDRYUP_COMMIT
+    elif [ -n "$FOUNDRYUP_PR" ]; then
+     FOUNDRYUP_VERSION=$AUTHOR-pr-$FOUNDRYUP_PR
+    else
+      if [ -n "$FOUNDRYUP_BRANCH" ]; then
+        NORMALIZED_BRANCH="$(echo "$FOUNDRYUP_BRANCH" | tr / -)"
+        FOUNDRYUP_VERSION=$AUTHOR-branch-$NORMALIZED_BRANCH
+      fi
+    fi
+    say "installing version $FOUNDRYUP_VERSION"
+
+    # Build the repo.
+    ensure cargo build --bins "${CARGO_BUILD_ARGS[@]}"
+    # Create sfoundry custom version directory.
+    ensure mkdir -p "$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_VERSION"
+    for bin in "${BINS[@]}"; do
+      for try_path in target/release/$bin target/release/$bin.exe; do
+        if [ -f "$try_path" ]; then
+          mv -f "$try_path" "$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_VERSION"
+        fi
+      done
+    done
+
+    # Use newly built version.
+    use
+
+    # If help2man is installed, use it to add Foundry man pages.
+    if check_cmd help2man; then
+      for bin in "${BINS[@]}"; do
+        help2man -N "$FOUNDRY_BIN_DIR/$bin" > "$FOUNDRY_MAN_DIR/$bin.1"
+      done
+    fi
+
+    say "done"
+  fi
 }
 
 install_ssolc() {
- echo "Starting ssolc installation..."
+  echo "Starting ssolc installation..."
 
- # Detect OS and set installation paths
- OS="$(uname -s)"
- ARCH="$(uname -m)"
+  # Detect OS and set installation paths
+  OS="$(uname -s)"
+  ARCH="$(uname -m)"
 
- case "$OS" in
-   Linux*)     
-     OS_TYPE="linux"
-     INSTALL_DIR="/usr/local/bin"
-     ;;
-   Darwin*)    
-     OS_TYPE="macos"
-     INSTALL_DIR="/usr/local/bin"
-     ;;
-   CYGWIN*|MINGW*|MSYS*|Windows_NT)
-     OS_TYPE="windows"
-     INSTALL_DIR="$PROGRAMFILES/Seismic/bin"
-     ;;
-   *)
-     echo "Unsupported OS: $OS"
-     exit 1
-     ;;
- esac
+  case "$OS" in
+    Linux*)
+      OS_TYPE="linux"
+      INSTALL_DIR="/usr/local/bin"
+      ;;
+    Darwin*)
+      OS_TYPE="macos"
+      INSTALL_DIR="/usr/local/bin"
+      ;;
+    *)
+      echo "Unsupported OS: $OS"
+      exit 1
+      ;;
+  esac
 
- case "$ARCH" in
-   x86_64)     ARCH_TYPE="x86_64" ;;
-   arm64|aarch64) ARCH_TYPE="arm64" ;;
-   *)
-     echo "Unsupported architecture: $ARCH"
-     exit 1
-     ;;
- esac
+  case "$ARCH" in
+    x86_64)     ARCH_TYPE="x86_64" ;;
+    arm64|aarch64) ARCH_TYPE="arm64" ;;
+    *)
+      echo "Unsupported architecture: $ARCH"
+      exit 1
+      ;;
+  esac
 
   # Set target info
-  TARGET_NAME="ssolc-${OS_TYPE}-${ARCH_TYPE}"
-  if [[ "$OS_TYPE" == "windows" ]]; then
-    TARGET_NAME="${TARGET_NAME}.zip"
-  else
-    TARGET_NAME="${TARGET_NAME}.tar.gz"
+  TARGET_NAME="ssolc-${OS_TYPE}-${ARCH_TYPE}.tar.gz"
+  SSOLC_BIN="${INSTALL_DIR}/ssolc"
+
+  TEMP_DIR=$(mktemp -d)
+  trap 'rm -rf "$TEMP_DIR"' EXIT
+
+  # Download the release
+  echo "Fetching latest release information..."
+  GITHUB_API_URL="https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/latest"
+  ASSET_ID=$(curl -s "$GITHUB_API_URL" | \
+      jq -r --arg name "$TARGET_NAME" '.assets[] | select(.name == $name) | .id')
+
+  if [[ -z "$ASSET_ID" ]]; then
+    echo "Error: Asset $TARGET_NAME not found in the latest release."
+    exit 1
   fi
-  
-  if [[ "$OS_TYPE" == "windows" ]]; then
-    SSOLC_BIN="${INSTALL_DIR}/ssolc.exe"
-  else
-    SSOLC_BIN="${INSTALL_DIR}/ssolc"
+
+  echo "Downloading $TARGET_NAME..."
+  DOWNLOAD_PATH="$TEMP_DIR/$TARGET_NAME"
+  curl -L -H "Accept: application/octet-stream" \
+       -o "$DOWNLOAD_PATH" \
+       "https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/assets/$ASSET_ID"
+
+  # Extract and install
+  echo "Extracting archive..."
+  mkdir -p "$TEMP_DIR/extract"
+
+  if ! file "$DOWNLOAD_PATH" | grep -q 'gzip compressed data'; then
+    echo "Error: Invalid gzip archive"
+    exit 1
+  fi
+  tar -xzf "$DOWNLOAD_PATH" -C "$TEMP_DIR/extract"
+  BINARY_PATH="$TEMP_DIR/extract/solc/solc"
+
+  if [[ ! -f "$BINARY_PATH" ]]; then
+    echo "Error: Binary not found in extracted archive"
+    exit 1
   fi
 
- TEMP_DIR=$(mktemp -d)
- trap 'rm -rf "$TEMP_DIR"' EXIT
+  # Install the binary
+  echo "Installing binary to $SSOLC_BIN..."
+  mkdir -p "$(dirname "$SSOLC_BIN")"
 
- # Download the release
- echo "Fetching latest release information..."
- GITHUB_API_URL="https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/latest"
- ASSET_ID=$(curl -s "$GITHUB_API_URL" | \
-     jq -r --arg name "$TARGET_NAME" '.assets[] | select(.name == $name) | .id')
+  sudo mv "$BINARY_PATH" "$SSOLC_BIN"
+  sudo chmod +x "$SSOLC_BIN"
 
- if [[ -z "$ASSET_ID" ]]; then
-   echo "Error: Asset $TARGET_NAME not found in the latest release."
-   exit 1
- fi
-
- echo "Downloading $TARGET_NAME..."
- DOWNLOAD_PATH="$TEMP_DIR/$TARGET_NAME"
- curl -L -H "Accept: application/octet-stream" \
-      -o "$DOWNLOAD_PATH" \
-      "https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/assets/$ASSET_ID"
-
- # Extract and install
- echo "Extracting archive..."
- mkdir -p "$TEMP_DIR/extract"
- 
- if [[ "$OS_TYPE" == "windows" ]]; then
-   if ! file "$DOWNLOAD_PATH" | grep -q 'Zip archive data'; then
-     echo "Error: Invalid zip archive"
-     exit 1
-   fi
-   unzip -q "$DOWNLOAD_PATH" -d "$TEMP_DIR/extract"
-   BINARY_PATH="$TEMP_DIR/extract/solc.exe"
- else
-   if ! file "$DOWNLOAD_PATH" | grep -q 'gzip compressed data'; then
-     echo "Error: Invalid gzip archive"
-     exit 1
-   fi
-   tar -xzf "$DOWNLOAD_PATH" -C "$TEMP_DIR/extract"
-   BINARY_PATH="$TEMP_DIR/extract/solc/solc"
- fi
-
- if [[ ! -f "$BINARY_PATH" ]]; then
-   echo "Error: Binary not found in extracted archive"
-   exit 1
- fi
-
- # Install the binary
- echo "Installing binary to $SSOLC_BIN..."
- mkdir -p "$(dirname "$SSOLC_BIN")"
- 
- if [[ "$OS_TYPE" == "windows" ]]; then
-   mv "$BINARY_PATH" "$SSOLC_BIN"
-   chmod +x "$SSOLC_BIN"
-   echo "Adding $INSTALL_DIR to PATH..."
-   setx PATH "%PATH%;$INSTALL_DIR"
-   echo "Please restart your terminal for PATH changes to take effect."
- else
-   sudo mv "$BINARY_PATH" "$SSOLC_BIN"
-   sudo chmod +x "$SSOLC_BIN"
- fi
-
- echo "Installation complete! ssolc installed at $SSOLC_BIN"
-}
-
-install_from_remote_repo() {
- SEISMICUP_REPO="SeismicSystems/seismic-foundry"
- SEISMICUP_BRANCH="seismic"
-
- need_cmd cargo
- say "Installing Seismic Foundry from $SEISMICUP_REPO (branch: $SEISMICUP_BRANCH)..."
-
- REPO_PATH="$SEISMIC_DIR/$(basename "$SEISMICUP_REPO")"
-
- # Clone the repository if it doesn't already exist
- if [ ! -d "$REPO_PATH" ]; then
-   ensure mkdir -p "$SEISMIC_DIR"
-   say "Cloning the repository..."
-   ensure git clone "https://github.com/$SEISMICUP_REPO.git" "$REPO_PATH"
- fi
-
- # Fetch and checkout the branch
- cd "$REPO_PATH"
- ensure git fetch origin "${SEISMICUP_BRANCH}:remotes/origin/${SEISMICUP_BRANCH}"
- ensure git checkout "origin/${SEISMICUP_BRANCH}"
-
- # Use the git CLI to fetch dependencies
- export CARGO_NET_GIT_FETCH_WITH_CLI=true
-
- # Build the binaries
- ensure cargo build --bins "${CARGO_BUILD_ARGS[@]}"
- for bin in "${BINS[@]}"; do
-   for try_path in target/release/$bin target/release/$bin.exe; do
-     if [ -f "$try_path" ]; then
-       [ -e "$SEISMIC_BIN_DIR/$bin" ] && warn "Overwriting existing $bin in $SEISMIC_BIN_DIR"
-       mv -f "$try_path" "$SEISMIC_BIN_DIR"
-     fi
-   done
- done
-
- say "Seismic Foundry installation complete."
+  echo "Installation complete! ssolc installed at $SSOLC_BIN"
 }
 
 usage() {
- cat 1>&2 <<EOF
+  cat 1>&2 <<EOF
 The installer for Seismic Foundry.
 
-Installs or updates ssolc, sforge, scast, sanvil, and schisel for Ethereum development.
+Update or revert to a specific Seismic Foundry version with ease.
+
+By default, the latest stable version is installed from built binaries.
 
 USAGE:
-   sfoundryup <OPTIONS>
+    sfoundryup <OPTIONS>
 
 OPTIONS:
-   -h, --help      Print help information
-   -v, --version   Install a specific version from built binaries
-   -p, --path      Build and install a local repository
-   -j, --jobs      Number of CPUs to use for building (default: all CPUs)
+    -h, --help      Print help information
+    -v, --version   Print the version of sfoundryup
+    -U, --update    Update sfoundryup to the latest version
+    -i, --install   Install a specific version from built binaries (e.g. nightly, v0.1.0)
+    -l, --list      List versions installed from built binaries
+    -u, --use       Use a specific installed version from built binaries
+    -b, --branch    Build and install a specific branch
+    -P, --pr        Build and install a specific Pull Request
+    -C, --commit    Build and install a specific commit
+    -r, --repo      Build and install from a remote GitHub repo (uses default branch if no other options are set)
+    -p, --path      Build and install a local repository
+    -j, --jobs      Number of CPUs to use for building (default: all CPUs)
+    -f, --force     Skip SHA verification for downloaded binaries (INSECURE - use with caution)
+    --arch          Install a specific architecture (supports amd64 and arm64)
+    --platform      Install a specific platform (supports linux and darwin)
 EOF
 }
 
+version() {
+  say "$FOUNDRYUP_INSTALLER_VERSION"
+  exit 0
+}
+
+update() {
+  say "updating sfoundryup..."
+
+  current_version="$FOUNDRYUP_INSTALLER_VERSION"
+
+  # Download the new version.
+  tmp_file="$(mktemp)"
+  ensure download "$FOUNDRY_BIN_URL" "$tmp_file"
+
+  # Extract new version from downloaded file.
+  new_version=$(grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' "$tmp_file" | cut -d'"' -f2)
+
+  # If the new version could not be determined, exit gracefully.
+  # This prevents from upgrading to an empty or invalid version.
+  if [ -z "$new_version" ]; then
+    warn "could not determine new sfoundryup version. Exiting."
+    rm -f "$tmp_file"
+    exit 0
+  fi
+
+  # If the new version is not greater than the current version, skip the update.
+  # This is to prevent downgrades or unnecessary updates.
+  if ! version_gt "$new_version" "$current_version"; then
+    say "sfoundryup is already up to date (installed: $current_version, remote: $new_version)."
+    rm -f "$tmp_file"
+    exit 0
+  fi
+
+  # Overwrite existing sfoundryup
+  ensure mv "$tmp_file" "$FOUNDRY_BIN_PATH"
+  ensure chmod +x "$FOUNDRY_BIN_PATH"
+
+  say "successfully updated sfoundryup: $current_version → $new_version"
+  exit 0
+}
+
+list() {
+  if [ -d "$FOUNDRY_VERSIONS_DIR" ]; then
+    for VERSION in $FOUNDRY_VERSIONS_DIR/*; do
+      say "${VERSION##*/}"
+      for bin in "${BINS[@]}"; do
+        bin_path="$VERSION/$bin"
+        say "- $(ensure "$bin_path" -V)"
+      done
+      printf "\n"
+    done
+  else
+    for bin in "${BINS[@]}"; do
+      bin_path="$FOUNDRY_BIN_DIR/$bin"
+      say "- $(ensure "$bin_path" -V)"
+    done
+  fi
+  exit 0
+}
+
+use() {
+  [ -z "$FOUNDRYUP_VERSION" ] && err "no version provided"
+  FOUNDRY_VERSION_DIR="$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_VERSION"
+  if [ -d "$FOUNDRY_VERSION_DIR" ]; then
+
+    check_bins_in_use
+
+    for bin in "${BINS[@]}"; do
+      bin_path="$FOUNDRY_BIN_DIR/$bin"
+      cp "$FOUNDRY_VERSION_DIR/$bin" "$bin_path"
+      # Print usage msg
+      say "use - $(ensure "$bin_path" -V)"
+
+      # Check if the default path of the binary is not in FOUNDRY_BIN_DIR
+      which_path="$(command -v "$bin" || true)"
+      if [ -n "$which_path" ] && [ "$which_path" != "$bin_path" ]; then
+        warn ""
+        cat 1>&2 <<EOF
+There are multiple binaries with the name '$bin' present in your 'PATH'.
+This may be the result of installing '$bin' using another method,
+like Cargo or other package managers.
+You may need to run 'rm $which_path' or move '$FOUNDRY_BIN_DIR'
+in your 'PATH' to allow the newly installed version to take precedence!
+
+EOF
+      fi
+    done
+    exit 0
+  else
+    err "version $FOUNDRYUP_VERSION not installed"
+  fi
+}
+
 say() {
- printf "sfoundryup: %s\n" "$1"
+  printf "sfoundryup: %s\n" "$1"
 }
 
 warn() {
- say "warning: $1" >&2
+  say "warning: ${1}" >&2
 }
 
 err() {
- say "$1" >&2
- exit 1
+  say "$1" >&2
+  exit 1
+}
+
+tolower() {
+  echo "$1" | awk '{print tolower($0)}'
+}
+
+compute_sha256() {
+  if check_cmd sha256sum; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
 }
 
 need_cmd() {
- if ! command -v "$1" &>/dev/null; then
-   err "Need '$1' (command not found)"
- fi
+  if ! check_cmd "$1"; then
+    err "need '$1' (command not found)"
+  fi
 }
 
+check_cmd() {
+  command -v "$1" &>/dev/null
+}
+
+check_installer_up_to_date() {
+  say "checking if sfoundryup is up to date..."
+
+  if check_cmd curl; then
+    # The || true prevents set -e from killing the script when the URL doesn't exist or GitHub is down, allowing us to handle the error gracefully.
+    remote_version=$(curl -fsSL "$FOUNDRY_BIN_URL" 2>/dev/null | grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' | cut -d'"' -f2) || true
+  else
+    remote_version=$(wget -qO- "$FOUNDRY_BIN_URL" 2>/dev/null | grep -Eo 'FOUNDRYUP_INSTALLER_VERSION="[0-9]+\.[0-9]+\.[0-9]+"' | cut -d'"' -f2) || true
+  fi
+
+  if [ -z "$remote_version" ]; then
+    warn "Could not determine remote sfoundryup version. Skipping version check."
+    return 0
+  fi
+
+  if version_gt "$remote_version" "$FOUNDRYUP_INSTALLER_VERSION"; then
+    printf '
+Your installation of sfoundryup is out of date.
+
+Installed: %s → Latest: %s
+
+To update, run:
+
+  sfoundryup --update
+
+Updating is highly recommended as it gives you access to the latest features and bug fixes.
+
+' "$FOUNDRYUP_INSTALLER_VERSION" "$remote_version" >&2
+  else
+    say "sfoundryup is up to date."
+  fi
+}
+
+# Compares two version strings in the format "major.minor.patch".
+# Returns 0 if $1 is greater than $2, 1 if $1 is less than $2, and 1 if they are equal.
+#
+# Assumes that the version strings are well-formed and contain three numeric components separated by dots.
+#
+# Example: version_gt "1.2.3" "1.2.4"
+#          returns 1 (1.2.3 < 1.2.4)
+#          version_gt "1.2.3" "1.2.3"
+#          returns 1 (1.2.3 == 1.2.3)
+#          version_gt "1.2.4" "1.2.3"
+#          returns 0 (1.2.4 > 1.2.3)
+version_gt() {
+  [ "$1" = "$2" ] && return 1
+
+  IFS=. read -r major1 minor1 patch1 <<EOF
+$1
+EOF
+  IFS=. read -r major2 minor2 patch2 <<EOF
+$2
+EOF
+
+  [ "$major1" -gt "$major2" ] && return 0
+  [ "$major1" -lt "$major2" ] && return 1
+  [ "$minor1" -gt "$minor2" ] && return 0
+  [ "$minor1" -lt "$minor2" ] && return 1
+  [ "$patch1" -gt "$patch2" ] && return 0
+  [ "$patch1" -lt "$patch2" ] && return 1
+
+  return 1
+}
+
+check_bins_in_use() {
+  if check_cmd pgrep; then
+    for bin in "${BINS[@]}"; do
+      if pgrep -x "$bin" >/dev/null; then
+        err "Error: '$bin' is currently running. Please stop the process and try again."
+      fi
+    done
+  else
+    warn "Make sure no foundry process is running during the install process!"
+  fi
+}
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing command.
 ensure() {
- if ! "$@"; then err "Command failed: $*"; fi
+  if ! "$@"; then err "command failed: $*"; fi
 }
 
-banner() {
- printf '
+# Downloads $1 into $2 or stdout
+download() {
+  if [ -n "$2" ]; then
+    # output into $2
+    if check_cmd curl; then
+      curl -#o "$2" -L "$1"
+    else
+      wget --show-progress -qO "$2" "$1"
+    fi
+  else
+    # output to stdout
+    if check_cmd curl; then
+      curl -#L "$1"
+    else
+      wget --show-progress -qO- "$1"
+    fi
+  fi
+}
 
- #####   #######   ######   #####   ##   ##   ######   #####            #######   #####   ### ###  ##  ###  ######   ######   ### ###  
-###  ##  ### ###     ##    ###  ##  ### ###     ##    ### ###           ###  ##  ### ###  ### ###  ### ###  ### ###  ### ###  ### ###  
-###      ###         ##    ###      #######     ##    ###               ###      ### ###  ### ###  #######  ### ###  ### ###  ### ###  
- #####   #####       ##     #####   #######     ##    ###       ######  #####    ### ###  ### ###  #######  ### ###  ######    #####   
-     ##  ###         ##         ##  ### ###     ##    ###               ###      ### ###  ### ###  ### ###  ### ###  ### ##     ###    
-###  ##  ### ###     ##    ###  ##  ### ###     ##    ### ###           ###      ### ###  ### ###  ### ###  ### ###  ### ###    ###    
- #####   #######   ######   #####   ### ###   ######   #####            ###       #####    #####   ### ###  ######   ### ###    ###      
+# Banner prompt for Seismic Foundry
+banner() {
+  printf '
+
+ #####   #######   ######   #####   ##   ##   ######   #####            #######   #####   ### ###  ##  ###  ######   ######   ### ###
+###  ##  ### ###     ##    ###  ##  ### ###     ##    ### ###           ###  ##  ### ###  ### ###  ### ###  ### ###  ### ###  ### ###
+###      ###         ##    ###      #######     ##    ###               ###      ### ###  ### ###  #######  ### ###  ### ###  ### ###
+ #####   #####       ##     #####   #######     ##    ###       ######  #####    ### ###  ### ###  #######  ### ###  ######    #####
+     ##  ###         ##         ##  ### ###     ##    ###               ###      ### ###  ### ###  ### ###  ### ###  ### ##     ###
+###  ##  ### ###     ##    ###  ##  ### ###     ##    ### ###           ###      ### ###  ### ###  ### ###  ### ###  ### ###    ###
+ #####   #######   ######   #####   ### ###   ######   #####            ###       #####    #####   ### ###  ######   ### ###    ###
 
 Repo       : https://github.com/SeismicSystems/seismic-foundry
+
 '
 }
+
 
 main "$@"

--- a/foundryup/install
+++ b/foundryup/install
@@ -3,65 +3,62 @@ set -eo pipefail
 
 echo "Installing sfoundryup..."
 
-# Define paths consistent with sfoundryup
 BASE_DIR="${XDG_CONFIG_HOME:-$HOME}"
-SEISMIC_DIR="${SEISMIC_DIR:-"$BASE_DIR/.seismic"}"
-SEISMIC_BIN_DIR="$SEISMIC_DIR/bin"
+FOUNDRY_DIR="${FOUNDRY_DIR:-"$BASE_DIR/.seismic"}"
+FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
+FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 
-BIN_PATH="$SEISMIC_BIN_DIR/sfoundryup"
+BIN_URL="https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/foundryup"
+BIN_PATH="$FOUNDRY_BIN_DIR/sfoundryup"
 
-
-# GitHub raw URL to sfoundryup
-RAW_API_URL="https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/foundryup"
-
-# Create necessary directories
-mkdir -p "$SEISMIC_BIN_DIR"
-
-# Download sfoundryup using GitHub raw content URL
-echo "Fetching sfoundryup..."
-curl -sSf "$RAW_API_URL" -o "$BIN_PATH"
-
-# Make the file executable
+# Create the .seismic bin directory and sfoundryup binary if it doesn't exist.
+mkdir -p "$FOUNDRY_BIN_DIR"
+curl -sSf -L "$BIN_URL" -o "$BIN_PATH"
 chmod +x "$BIN_PATH"
 
-# Update the PATH environment variable
+# Create the man directory for future man files if it doesn't exist.
+mkdir -p "$FOUNDRY_MAN_DIR"
+
+# Store the correct profile file (i.e. .profile for bash or .zshenv for ZSH).
 case $SHELL in
 */zsh)
-    PROFILE="${ZDOTDIR:-$HOME}/.zshenv"
+    PROFILE="${ZDOTDIR-"$HOME"}/.zshenv"
+    PREF_SHELL=zsh
     ;;
 */bash)
-    PROFILE="$HOME/.bashrc"
+    PROFILE=$HOME/.bashrc
+    PREF_SHELL=bash
     ;;
 */fish)
-    PROFILE="$HOME/.config/fish/config.fish"
+    PROFILE=$HOME/.config/fish/config.fish
+    PREF_SHELL=fish
     ;;
 */ash)
-    PROFILE="$HOME/.profile"
+    PROFILE=$HOME/.profile
+    PREF_SHELL=ash
     ;;
 *)
-    echo "Could not detect shell. Please manually add $SEISMIC_BIN_DIR to your PATH."
+    echo "sfoundryup: could not detect shell, manually add ${FOUNDRY_BIN_DIR} to your PATH."
     exit 1
 esac
 
-if [[ ":$PATH:" != *":$SEISMIC_BIN_DIR:"* ]]; then
-    if [[ "$SHELL" == *fish ]]; then
-        echo >> "$PROFILE" && echo "fish_add_path $SEISMIC_BIN_DIR" >> "$PROFILE"
+# Only add sfoundryup if it isn't already in PATH.
+if [[ ":$PATH:" != *":${FOUNDRY_BIN_DIR}:"* ]]; then
+    # Add the sfoundryup directory to the path and ensure the old PATH variables remain.
+    # If the shell is fish, echo fish_add_path instead of export.
+    if [[ "$PREF_SHELL" == "fish" ]]; then
+        echo >> "$PROFILE" && echo "fish_add_path -a \"$FOUNDRY_BIN_DIR\"" >> "$PROFILE"
     else
-        echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$SEISMIC_BIN_DIR\"" >> "$PROFILE"
+        echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$FOUNDRY_BIN_DIR\"" >> "$PROFILE"
     fi
 fi
 
-# Ensure prerequisites are installed
-echo "Checking prerequisites..."
-for cmd in git curl; do
-    if ! command -v "$cmd" >/dev/null; then
-        echo "Error: $cmd is required but not installed. Please install it and re-run this script."
-        exit 1
-    fi
-done
+# Warn MacOS users that they may need to manually install libusb via Homebrew:
+if [[ "$OSTYPE" =~ ^darwin ]] && [[ ! -f /usr/local/opt/libusb/lib/libusb-1.0.0.dylib ]] && [[ ! -f /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib ]]; then
+    echo && echo "warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install libusb)."
+fi
 
-# Print completion message
 echo
-echo "sfoundryup installed successfully at $SEISMIC_BIN_DIR/sfoundryup."
+echo "Detected your preferred shell is $PREF_SHELL and added sfoundryup to PATH."
 echo "Run 'source $PROFILE' or start a new terminal session to use sfoundryup."
-echo "Then, run 'sfoundryup' to install Seismic Foundry tools."
+echo "Then, simply run 'sfoundryup' to install Seismic Foundry."


### PR DESCRIPTION
We had forked and drastically simplified foundryup to the point where the only install option was cloning the repo and install from source, which is very slow. Now that our CI builds release binaries, it makes sense to make sfoundryup able to download those.

I reverted foundryup to match upstream (master branch) and then made the minimal diff to make it work for our usecase (eg changing `foundryup` -> `sfoundryup` everywhere).

The default option is also now to download the latest published release, which means users won't get broken everytime we push a temporary small bug to seismic branch. Also gives us some time to plan breaking change upgrades.

Currently we don't have any published releases (only nightly pre-releases) so `sfoundryup` will fail. I will fix this in a subsequent PR by fixing our release CI and publishing a first v0.1.0 release. We will then in the future just need to tag versions for CI to build a new release version which will then be downloaded by sfoundryup automatically.

Users can also get the latest nightly release by using `sfoundryup -i nightly`

With this change sfoundryup can now also manage multiple versions:
```
$ ./foundryup/foundryup --list
sfoundryup: nightly
sfoundryup: - sforge 1.3.5-nightly (94eb5fc14e 2026-03-16T06:43:41.332565000Z)
sfoundryup: - cast 1.3.5-nightly (94eb5fc14e 2026-03-16T06:43:41.332565000Z)
sfoundryup: - anvil 1.3.5-nightly (94eb5fc14e 2026-03-16T06:43:41.332565000Z)
sfoundryup: - chisel 1.3.5-nightly (94eb5fc14e 2026-03-16T06:43:41.332565000Z)

sfoundryup: nightly-557cad357702a1027bb8d3d245f8d9d28626d127
sfoundryup: - sforge 1.3.5-nightly (557cad3577 2026-03-09T06:34:02.839560000Z)
sfoundryup: - cast 1.3.5-nightly (557cad3577 2026-03-09T06:34:02.839560000Z)
sfoundryup: - anvil 1.3.5-nightly (557cad3577 2026-03-09T06:34:02.839560000Z)
sfoundryup: - chisel 1.3.5-nightly (557cad3577 2026-03-09T06:34:02.839560000Z)
```

## Note to reviewers

The diff looks huge but its now very minimal with upstream. Instead of checking this PR's diff, better to checkout this branch locally and run `git diff master`.