### PR TITLE
ci(release): update nightly release date

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,18 @@ jobs:
             const createTag = require('./.github/scripts/create-tag.js')
             await createTag({ github, context }, process.env.TAG_NAME)
 
+      # GitHub derives the release date from the tag creation date.
+      # Delete and recreate the `nightly` tag so the release page
+      # shows today's date instead of when the tag was first created.
+      # See: https://github.com/softprops/action-gh-release/issues/171
+      - name: Recreate nightly tag
+        if: ${{ env.IS_NIGHTLY == 'true' }}
+        run: |
+          git tag -d nightly || true
+          git push origin :refs/tags/nightly || true
+          git tag nightly
+          git push origin nightly
+
       # For versioned releases (v*.*.*), find the previous semver tag to compute changelog from.
       # Unlike upstream which uses a hardcoded STABLE_VERSION env var, we resolve it dynamically
       # so we don't have to remember to update it after each release.


### PR DESCRIPTION
Currently when running the nightly release CI, it updates the nightly release, but doesn't update its date.
So we end up with:
<img width="756" height="538" alt="image" src="https://github.com/user-attachments/assets/fd1697ea-bf30-4e77-acdc-e9e99328a430" />

This is an attempt at fixing that (not 100% sure it works yet..).
