### PR TITLE
refactor: extract SeismicError enum from SolidityErrorCode

### DIFF
--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -4,6 +4,8 @@ use figment::providers::{Format, Toml};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{error::Error, fmt, str::FromStr};
 
+use crate::seismic_error::SeismicError;
+
 /// Represents a failed attempt to extract `Config` from a `Figment`
 #[derive(Clone, PartialEq)]
 pub struct ExtractConfigError {
@@ -145,31 +147,9 @@ pub enum SolidityErrorCode {
     TransientStorageUsed,
     /// There are more than 256 warnings. Ignoring the rest.
     TooManyWarnings,
-    /// Warning: constructor has shielded parameter types (CREATE doesn't encrypt calldata)
-    ShieldedConstructorParam,
-    /// Warning: shielded literal in `new(...)` expression args (int)
-    ShieldedLiteralNewExprInt,
-    /// Warning: shielded literal in `new(...)` expression args (bool)
-    ShieldedLiteralNewExprBool,
-    /// Warning: shielded literal in `new(...)` expression args (address)
-    ShieldedLiteralNewExprAddress,
-    /// Warning: shielded literal in `new(...)` expression args (fixedbytes)
-    ShieldedLiteralNewExprFixedbytes,
-    /// Warning: shielded literal in `new(...)` expression args (enum)
-    ShieldedLiteralNewExprEnum,
-    /// Warning: shielded literal in external call args (int)
-    ShieldedLiteralExtCallInt,
-    /// Warning: shielded literal in external call args (bool)
-    ShieldedLiteralExtCallBool,
-    /// Warning: shielded literal in external call args (address)
-    ShieldedLiteralExtCallAddress,
-    /// Warning: shielded literal in external call args (fixedbytes)
-    ShieldedLiteralExtCallFixedbytes,
-    /// Warning: shielded literal in external call args (enum)
-    ShieldedLiteralExtCallEnum,
+    /// Seismic/ssolc warning (code >= 10000) with a named variant.
+    Seismic(SeismicError),
     /// All other error codes
-    /// Note: Seismic/ssolc warning codes (>= 10000) not listed above (e.g. "other context"
-    /// 10403-10415, s-literal 10416) are handled via `Other(code)`.
     Other(u64),
 }
 
@@ -196,17 +176,7 @@ impl SolidityErrorCode {
             Self::PragmaSolidity => "pragma-solidity",
             Self::TransientStorageUsed => "transient-storage",
             Self::TooManyWarnings => "too-many-warnings",
-            Self::ShieldedConstructorParam => "shielded-constructor-param",
-            Self::ShieldedLiteralNewExprInt => "shielded-literal-new-int",
-            Self::ShieldedLiteralNewExprBool => "shielded-literal-new-bool",
-            Self::ShieldedLiteralNewExprAddress => "shielded-literal-new-address",
-            Self::ShieldedLiteralNewExprFixedbytes => "shielded-literal-new-fixedbytes",
-            Self::ShieldedLiteralNewExprEnum => "shielded-literal-new-enum",
-            Self::ShieldedLiteralExtCallInt => "shielded-literal-ext-call-int",
-            Self::ShieldedLiteralExtCallBool => "shielded-literal-ext-call-bool",
-            Self::ShieldedLiteralExtCallAddress => "shielded-literal-ext-call-address",
-            Self::ShieldedLiteralExtCallFixedbytes => "shielded-literal-ext-call-fixedbytes",
-            Self::ShieldedLiteralExtCallEnum => "shielded-literal-ext-call-enum",
+            Self::Seismic(s) => return Ok(s.as_str()),
             Self::Other(code) => return Err(*code),
         };
         Ok(s)
@@ -233,17 +203,7 @@ impl From<SolidityErrorCode> for u64 {
             SolidityErrorCode::PragmaSolidity => 3420,
             SolidityErrorCode::TransientStorageUsed => 2394,
             SolidityErrorCode::TooManyWarnings => 4591,
-            SolidityErrorCode::ShieldedConstructorParam => 10103,
-            SolidityErrorCode::ShieldedLiteralNewExprInt => 10401,
-            SolidityErrorCode::ShieldedLiteralNewExprBool => 10404,
-            SolidityErrorCode::ShieldedLiteralNewExprAddress => 10407,
-            SolidityErrorCode::ShieldedLiteralNewExprFixedbytes => 10410,
-            SolidityErrorCode::ShieldedLiteralNewExprEnum => 10413,
-            SolidityErrorCode::ShieldedLiteralExtCallInt => 10402,
-            SolidityErrorCode::ShieldedLiteralExtCallBool => 10405,
-            SolidityErrorCode::ShieldedLiteralExtCallAddress => 10408,
-            SolidityErrorCode::ShieldedLiteralExtCallFixedbytes => 10411,
-            SolidityErrorCode::ShieldedLiteralExtCallEnum => 10414,
+            SolidityErrorCode::Seismic(s) => s.code(),
             SolidityErrorCode::Other(code) => code,
         }
     }
@@ -280,18 +240,12 @@ impl FromStr for SolidityErrorCode {
             "pragma-solidity" => Self::PragmaSolidity,
             "transient-storage" => Self::TransientStorageUsed,
             "too-many-warnings" => Self::TooManyWarnings,
-            "shielded-constructor-param" => Self::ShieldedConstructorParam,
-            "shielded-literal-new-int" => Self::ShieldedLiteralNewExprInt,
-            "shielded-literal-new-bool" => Self::ShieldedLiteralNewExprBool,
-            "shielded-literal-new-address" => Self::ShieldedLiteralNewExprAddress,
-            "shielded-literal-new-fixedbytes" => Self::ShieldedLiteralNewExprFixedbytes,
-            "shielded-literal-new-enum" => Self::ShieldedLiteralNewExprEnum,
-            "shielded-literal-ext-call-int" => Self::ShieldedLiteralExtCallInt,
-            "shielded-literal-ext-call-bool" => Self::ShieldedLiteralExtCallBool,
-            "shielded-literal-ext-call-address" => Self::ShieldedLiteralExtCallAddress,
-            "shielded-literal-ext-call-fixedbytes" => Self::ShieldedLiteralExtCallFixedbytes,
-            "shielded-literal-ext-call-enum" => Self::ShieldedLiteralExtCallEnum,
-            _ => return Err(format!("Unknown variant {s}")),
+            s => {
+                if let Some(seismic) = SeismicError::from_alias(s) {
+                    return Ok(Self::Seismic(seismic));
+                }
+                return Err(format!("Unknown variant {s}"));
+            }
         };
 
         Ok(code)
@@ -318,18 +272,13 @@ impl From<u64> for SolidityErrorCode {
             3420 => Self::PragmaSolidity,
             2394 => Self::TransientStorageUsed,
             4591 => Self::TooManyWarnings,
-            10103 => Self::ShieldedConstructorParam,
-            10401 => Self::ShieldedLiteralNewExprInt,
-            10404 => Self::ShieldedLiteralNewExprBool,
-            10407 => Self::ShieldedLiteralNewExprAddress,
-            10410 => Self::ShieldedLiteralNewExprFixedbytes,
-            10413 => Self::ShieldedLiteralNewExprEnum,
-            10402 => Self::ShieldedLiteralExtCallInt,
-            10405 => Self::ShieldedLiteralExtCallBool,
-            10408 => Self::ShieldedLiteralExtCallAddress,
-            10411 => Self::ShieldedLiteralExtCallFixedbytes,
-            10414 => Self::ShieldedLiteralExtCallEnum,
-            other => Self::Other(other),
+            other => {
+                if let Some(seismic) = SeismicError::from_code(other) {
+                    Self::Seismic(seismic)
+                } else {
+                    Self::Other(other)
+                }
+            }
         }
     }
 }
@@ -369,90 +318,70 @@ impl<'de> Deserialize<'de> for SolidityErrorCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::seismic_error::SeismicError;
 
-    /// All shielded warning variants with their numeric IDs and string aliases.
-    const SHIELDED_VARIANTS: &[(SolidityErrorCode, u64, &str)] = &[
-        (SolidityErrorCode::ShieldedConstructorParam, 10103, "shielded-constructor-param"),
-        (SolidityErrorCode::ShieldedLiteralNewExprInt, 10401, "shielded-literal-new-int"),
-        (SolidityErrorCode::ShieldedLiteralNewExprBool, 10404, "shielded-literal-new-bool"),
-        (SolidityErrorCode::ShieldedLiteralNewExprAddress, 10407, "shielded-literal-new-address"),
-        (
-            SolidityErrorCode::ShieldedLiteralNewExprFixedbytes,
-            10410,
-            "shielded-literal-new-fixedbytes",
-        ),
-        (SolidityErrorCode::ShieldedLiteralNewExprEnum, 10413, "shielded-literal-new-enum"),
-        (SolidityErrorCode::ShieldedLiteralExtCallInt, 10402, "shielded-literal-ext-call-int"),
-        (SolidityErrorCode::ShieldedLiteralExtCallBool, 10405, "shielded-literal-ext-call-bool"),
-        (
-            SolidityErrorCode::ShieldedLiteralExtCallAddress,
-            10408,
-            "shielded-literal-ext-call-address",
-        ),
-        (
-            SolidityErrorCode::ShieldedLiteralExtCallFixedbytes,
-            10411,
-            "shielded-literal-ext-call-fixedbytes",
-        ),
-        (SolidityErrorCode::ShieldedLiteralExtCallEnum, 10414, "shielded-literal-ext-call-enum"),
-    ];
+    /// Helper to wrap a SeismicError in SolidityErrorCode.
+    fn seismic(s: SeismicError) -> SolidityErrorCode {
+        SolidityErrorCode::Seismic(s)
+    }
 
     #[test]
-    fn shielded_variant_from_u64() {
-        for &(expected_variant, id, _) in SHIELDED_VARIANTS {
-            let variant: SolidityErrorCode = id.into();
-            assert_eq!(variant, expected_variant, "From<u64> for {id} should yield named variant");
-            // Must NOT be Other(id)
-            assert_ne!(
-                variant,
-                SolidityErrorCode::Other(id),
-                "{id} should not fall through to Other"
-            );
+    fn all_seismic_variants_roundtrip_u64() {
+        for variant in SeismicError::ALL {
+            let code = variant.code();
+            let sol: SolidityErrorCode = code.into();
+            assert_eq!(sol, seismic(*variant), "From<u64> for {code} should yield Seismic variant");
+            assert_ne!(sol, SolidityErrorCode::Other(code), "{code} should not fall through to Other");
+            let back: u64 = sol.into();
+            assert_eq!(back, code, "u64 round-trip failed for {code}");
         }
     }
 
     #[test]
-    fn shielded_variant_to_u64() {
-        for &(variant, expected_id, _) in SHIELDED_VARIANTS {
-            let id: u64 = variant.into();
-            assert_eq!(id, expected_id, "u64 from {variant:?} should be {expected_id}");
+    fn all_seismic_variants_roundtrip_str() {
+        for variant in SeismicError::ALL {
+            let sol = seismic(*variant);
+            let s = sol.as_str().unwrap();
+            assert_eq!(s, variant.as_str(), "as_str() mismatch for {variant:?}");
+            let parsed: SolidityErrorCode = s.parse().unwrap();
+            assert_eq!(parsed, sol, "FromStr round-trip failed for {s}");
         }
     }
 
     #[test]
-    fn shielded_variant_u64_roundtrip() {
-        for &(variant, id, _) in SHIELDED_VARIANTS {
-            let converted: u64 = variant.into();
-            let back: SolidityErrorCode = converted.into();
-            assert_eq!(back, variant, "u64 round-trip failed for {id}");
-        }
+    fn legacy_variant_names_still_parse() {
+        // Ensure the string aliases from #181 still work
+        assert_eq!(
+            "shielded-constructor-param".parse::<SolidityErrorCode>().unwrap(),
+            seismic(SeismicError::ShieldedConstructorParam),
+        );
+        assert_eq!(
+            "shielded-literal-new-int".parse::<SolidityErrorCode>().unwrap(),
+            seismic(SeismicError::ShieldedLiteralNewExprInt),
+        );
+        assert_eq!(
+            "shielded-literal-ext-call-int".parse::<SolidityErrorCode>().unwrap(),
+            seismic(SeismicError::ShieldedLiteralExtCallInt),
+        );
     }
 
     #[test]
-    fn shielded_variant_as_str() {
-        for &(variant, _, expected_str) in SHIELDED_VARIANTS {
-            assert_eq!(
-                variant.as_str().unwrap(),
-                expected_str,
-                "as_str() mismatch for {variant:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn shielded_variant_from_str() {
-        for &(expected_variant, _, alias) in SHIELDED_VARIANTS {
-            let parsed: SolidityErrorCode = alias.parse().unwrap();
-            assert_eq!(parsed, expected_variant, "FromStr mismatch for {alias:?}");
-        }
-    }
-
-    #[test]
-    fn shielded_variant_str_roundtrip() {
-        for &(variant, _, _) in SHIELDED_VARIANTS {
-            let s = variant.as_str().unwrap();
-            let back: SolidityErrorCode = s.parse().unwrap();
-            assert_eq!(back, variant, "str round-trip failed for {s}");
-        }
+    fn new_variant_names_parse() {
+        assert_eq!(
+            "shielded-literal-other-int".parse::<SolidityErrorCode>().unwrap(),
+            seismic(SeismicError::ShieldedLiteralOtherInt),
+        );
+        assert_eq!(
+            "shielded-number-literal".parse::<SolidityErrorCode>().unwrap(),
+            seismic(SeismicError::ShieldedNumberLiteral),
+        );
+        assert_eq!(
+            "shielded-arith-add".parse::<SolidityErrorCode>().unwrap(),
+            seismic(SeismicError::ShieldedArithAdd),
+        );
+        assert_eq!(
+            "shielded-cond-if".parse::<SolidityErrorCode>().unwrap(),
+            seismic(SeismicError::ShieldedCondIf),
+        );
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -87,6 +87,9 @@ pub mod error;
 use error::ExtractConfigError;
 pub use error::SolidityErrorCode;
 
+pub mod seismic_error;
+pub use seismic_error::SeismicError;
+
 pub mod doc;
 pub use doc::DocConfig;
 

--- a/crates/config/src/seismic_error.rs
+++ b/crates/config/src/seismic_error.rs
@@ -1,0 +1,334 @@
+//! Seismic-specific ssolc warning codes.
+//!
+//! Kept in a separate file to minimize the diff against upstream `error.rs`.
+
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+
+/// Named variants for all seismic/ssolc warning codes (>= 10000).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SeismicError {
+    // -- Arithmetic / branching warnings (10301-10311) --
+    /// Shielded addition leaks if operands are public
+    ShieldedArithAdd,
+    /// Shielded subtraction leaks if operands are public
+    ShieldedArithSub,
+    /// Shielded multiplication leaks if operands are public
+    ShieldedArithMul,
+    /// Shielded division leaks if operands are public
+    ShieldedArithDiv,
+    /// Shielded modulo leaks if operands are public
+    ShieldedArithMod,
+    /// Shielded exponentiation leaks if operands are public
+    ShieldedArithExp,
+    /// Shielded shift-left leaks if operands are public
+    ShieldedArithShl,
+    /// Shielded shift-right leaks if operands are public
+    ShieldedArithShr,
+    /// Shielded value used as if-condition (leaks via branch)
+    ShieldedCondIf,
+    /// Shielded value used as ternary condition (leaks via branch)
+    ShieldedCondTernary,
+    /// Shielded value used as while/for condition (leaks via branch)
+    ShieldedCondLoop,
+
+    // -- Constructor param warning (10103) --
+    /// Constructor has shielded parameter types (CREATE doesn't encrypt calldata)
+    ShieldedConstructorParam,
+
+    // -- Literal in `new(...)` expression args (10401, 10404, 10407, 10410, 10413) --
+    /// Shielded literal in `new(...)` expression args (int)
+    ShieldedLiteralNewExprInt,
+    /// Shielded literal in `new(...)` expression args (bool)
+    ShieldedLiteralNewExprBool,
+    /// Shielded literal in `new(...)` expression args (address)
+    ShieldedLiteralNewExprAddress,
+    /// Shielded literal in `new(...)` expression args (fixedbytes)
+    ShieldedLiteralNewExprFixedbytes,
+    /// Shielded literal in `new(...)` expression args (enum)
+    ShieldedLiteralNewExprEnum,
+
+    // -- Literal in external call args (10402, 10405, 10408, 10411, 10414) --
+    /// Shielded literal in external call args (int)
+    ShieldedLiteralExtCallInt,
+    /// Shielded literal in external call args (bool)
+    ShieldedLiteralExtCallBool,
+    /// Shielded literal in external call args (address)
+    ShieldedLiteralExtCallAddress,
+    /// Shielded literal in external call args (fixedbytes)
+    ShieldedLiteralExtCallFixedbytes,
+    /// Shielded literal in external call args (enum)
+    ShieldedLiteralExtCallEnum,
+
+    // -- Literal in other contexts (10403, 10406, 10409, 10412, 10415) --
+    /// Shielded literal in other context (int)
+    ShieldedLiteralOtherInt,
+    /// Shielded literal in other context (bool)
+    ShieldedLiteralOtherBool,
+    /// Shielded literal in other context (address)
+    ShieldedLiteralOtherAddress,
+    /// Shielded literal in other context (fixedbytes)
+    ShieldedLiteralOtherFixedbytes,
+    /// Shielded literal in other context (enum)
+    ShieldedLiteralOtherEnum,
+
+    // -- S-literal syntax (10416) --
+    /// Shielded number literal (s-literal syntax, e.g. `5s`)
+    ShieldedNumberLiteral,
+}
+
+impl SeismicError {
+    /// String alias usable in `foundry.toml` `ignored_error_codes`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ShieldedArithAdd => "shielded-arith-add",
+            Self::ShieldedArithSub => "shielded-arith-sub",
+            Self::ShieldedArithMul => "shielded-arith-mul",
+            Self::ShieldedArithDiv => "shielded-arith-div",
+            Self::ShieldedArithMod => "shielded-arith-mod",
+            Self::ShieldedArithExp => "shielded-arith-exp",
+            Self::ShieldedArithShl => "shielded-arith-shl",
+            Self::ShieldedArithShr => "shielded-arith-shr",
+            Self::ShieldedCondIf => "shielded-cond-if",
+            Self::ShieldedCondTernary => "shielded-cond-ternary",
+            Self::ShieldedCondLoop => "shielded-cond-loop",
+            Self::ShieldedConstructorParam => "shielded-constructor-param",
+            Self::ShieldedLiteralNewExprInt => "shielded-literal-new-int",
+            Self::ShieldedLiteralNewExprBool => "shielded-literal-new-bool",
+            Self::ShieldedLiteralNewExprAddress => "shielded-literal-new-address",
+            Self::ShieldedLiteralNewExprFixedbytes => "shielded-literal-new-fixedbytes",
+            Self::ShieldedLiteralNewExprEnum => "shielded-literal-new-enum",
+            Self::ShieldedLiteralExtCallInt => "shielded-literal-ext-call-int",
+            Self::ShieldedLiteralExtCallBool => "shielded-literal-ext-call-bool",
+            Self::ShieldedLiteralExtCallAddress => "shielded-literal-ext-call-address",
+            Self::ShieldedLiteralExtCallFixedbytes => "shielded-literal-ext-call-fixedbytes",
+            Self::ShieldedLiteralExtCallEnum => "shielded-literal-ext-call-enum",
+            Self::ShieldedLiteralOtherInt => "shielded-literal-other-int",
+            Self::ShieldedLiteralOtherBool => "shielded-literal-other-bool",
+            Self::ShieldedLiteralOtherAddress => "shielded-literal-other-address",
+            Self::ShieldedLiteralOtherFixedbytes => "shielded-literal-other-fixedbytes",
+            Self::ShieldedLiteralOtherEnum => "shielded-literal-other-enum",
+            Self::ShieldedNumberLiteral => "shielded-number-literal",
+        }
+    }
+
+    /// Numeric ssolc warning code.
+    pub fn code(&self) -> u64 {
+        match self {
+            Self::ShieldedArithAdd => 10301,
+            Self::ShieldedArithSub => 10302,
+            Self::ShieldedArithMul => 10303,
+            Self::ShieldedArithDiv => 10304,
+            Self::ShieldedArithMod => 10305,
+            Self::ShieldedArithExp => 10306,
+            Self::ShieldedArithShl => 10307,
+            Self::ShieldedArithShr => 10308,
+            Self::ShieldedCondIf => 10309,
+            Self::ShieldedCondTernary => 10310,
+            Self::ShieldedCondLoop => 10311,
+            Self::ShieldedConstructorParam => 10103,
+            Self::ShieldedLiteralNewExprInt => 10401,
+            Self::ShieldedLiteralNewExprBool => 10404,
+            Self::ShieldedLiteralNewExprAddress => 10407,
+            Self::ShieldedLiteralNewExprFixedbytes => 10410,
+            Self::ShieldedLiteralNewExprEnum => 10413,
+            Self::ShieldedLiteralExtCallInt => 10402,
+            Self::ShieldedLiteralExtCallBool => 10405,
+            Self::ShieldedLiteralExtCallAddress => 10408,
+            Self::ShieldedLiteralExtCallFixedbytes => 10411,
+            Self::ShieldedLiteralExtCallEnum => 10414,
+            Self::ShieldedLiteralOtherInt => 10403,
+            Self::ShieldedLiteralOtherBool => 10406,
+            Self::ShieldedLiteralOtherAddress => 10409,
+            Self::ShieldedLiteralOtherFixedbytes => 10412,
+            Self::ShieldedLiteralOtherEnum => 10415,
+            Self::ShieldedNumberLiteral => 10416,
+        }
+    }
+
+    /// Try to convert a numeric code to a named seismic variant.
+    pub fn from_code(code: u64) -> Option<Self> {
+        Some(match code {
+            10301 => Self::ShieldedArithAdd,
+            10302 => Self::ShieldedArithSub,
+            10303 => Self::ShieldedArithMul,
+            10304 => Self::ShieldedArithDiv,
+            10305 => Self::ShieldedArithMod,
+            10306 => Self::ShieldedArithExp,
+            10307 => Self::ShieldedArithShl,
+            10308 => Self::ShieldedArithShr,
+            10309 => Self::ShieldedCondIf,
+            10310 => Self::ShieldedCondTernary,
+            10311 => Self::ShieldedCondLoop,
+            10103 => Self::ShieldedConstructorParam,
+            10401 => Self::ShieldedLiteralNewExprInt,
+            10404 => Self::ShieldedLiteralNewExprBool,
+            10407 => Self::ShieldedLiteralNewExprAddress,
+            10410 => Self::ShieldedLiteralNewExprFixedbytes,
+            10413 => Self::ShieldedLiteralNewExprEnum,
+            10402 => Self::ShieldedLiteralExtCallInt,
+            10405 => Self::ShieldedLiteralExtCallBool,
+            10408 => Self::ShieldedLiteralExtCallAddress,
+            10411 => Self::ShieldedLiteralExtCallFixedbytes,
+            10414 => Self::ShieldedLiteralExtCallEnum,
+            10403 => Self::ShieldedLiteralOtherInt,
+            10406 => Self::ShieldedLiteralOtherBool,
+            10409 => Self::ShieldedLiteralOtherAddress,
+            10412 => Self::ShieldedLiteralOtherFixedbytes,
+            10415 => Self::ShieldedLiteralOtherEnum,
+            10416 => Self::ShieldedNumberLiteral,
+            _ => return None,
+        })
+    }
+
+    /// Try to parse a string alias to a named seismic variant.
+    pub fn from_alias(s: &str) -> Option<Self> {
+        Some(match s {
+            "shielded-arith-add" => Self::ShieldedArithAdd,
+            "shielded-arith-sub" => Self::ShieldedArithSub,
+            "shielded-arith-mul" => Self::ShieldedArithMul,
+            "shielded-arith-div" => Self::ShieldedArithDiv,
+            "shielded-arith-mod" => Self::ShieldedArithMod,
+            "shielded-arith-exp" => Self::ShieldedArithExp,
+            "shielded-arith-shl" => Self::ShieldedArithShl,
+            "shielded-arith-shr" => Self::ShieldedArithShr,
+            "shielded-cond-if" => Self::ShieldedCondIf,
+            "shielded-cond-ternary" => Self::ShieldedCondTernary,
+            "shielded-cond-loop" => Self::ShieldedCondLoop,
+            "shielded-constructor-param" => Self::ShieldedConstructorParam,
+            "shielded-literal-new-int" => Self::ShieldedLiteralNewExprInt,
+            "shielded-literal-new-bool" => Self::ShieldedLiteralNewExprBool,
+            "shielded-literal-new-address" => Self::ShieldedLiteralNewExprAddress,
+            "shielded-literal-new-fixedbytes" => Self::ShieldedLiteralNewExprFixedbytes,
+            "shielded-literal-new-enum" => Self::ShieldedLiteralNewExprEnum,
+            "shielded-literal-ext-call-int" => Self::ShieldedLiteralExtCallInt,
+            "shielded-literal-ext-call-bool" => Self::ShieldedLiteralExtCallBool,
+            "shielded-literal-ext-call-address" => Self::ShieldedLiteralExtCallAddress,
+            "shielded-literal-ext-call-fixedbytes" => Self::ShieldedLiteralExtCallFixedbytes,
+            "shielded-literal-ext-call-enum" => Self::ShieldedLiteralExtCallEnum,
+            "shielded-literal-other-int" => Self::ShieldedLiteralOtherInt,
+            "shielded-literal-other-bool" => Self::ShieldedLiteralOtherBool,
+            "shielded-literal-other-address" => Self::ShieldedLiteralOtherAddress,
+            "shielded-literal-other-fixedbytes" => Self::ShieldedLiteralOtherFixedbytes,
+            "shielded-literal-other-enum" => Self::ShieldedLiteralOtherEnum,
+            "shielded-number-literal" => Self::ShieldedNumberLiteral,
+            _ => return None,
+        })
+    }
+
+    /// All known seismic variants, for exhaustive testing.
+    pub const ALL: &'static [SeismicError] = &[
+        Self::ShieldedArithAdd,
+        Self::ShieldedArithSub,
+        Self::ShieldedArithMul,
+        Self::ShieldedArithDiv,
+        Self::ShieldedArithMod,
+        Self::ShieldedArithExp,
+        Self::ShieldedArithShl,
+        Self::ShieldedArithShr,
+        Self::ShieldedCondIf,
+        Self::ShieldedCondTernary,
+        Self::ShieldedCondLoop,
+        Self::ShieldedConstructorParam,
+        Self::ShieldedLiteralNewExprInt,
+        Self::ShieldedLiteralNewExprBool,
+        Self::ShieldedLiteralNewExprAddress,
+        Self::ShieldedLiteralNewExprFixedbytes,
+        Self::ShieldedLiteralNewExprEnum,
+        Self::ShieldedLiteralExtCallInt,
+        Self::ShieldedLiteralExtCallBool,
+        Self::ShieldedLiteralExtCallAddress,
+        Self::ShieldedLiteralExtCallFixedbytes,
+        Self::ShieldedLiteralExtCallEnum,
+        Self::ShieldedLiteralOtherInt,
+        Self::ShieldedLiteralOtherBool,
+        Self::ShieldedLiteralOtherAddress,
+        Self::ShieldedLiteralOtherFixedbytes,
+        Self::ShieldedLiteralOtherEnum,
+        Self::ShieldedNumberLiteral,
+    ];
+}
+
+impl fmt::Display for SeismicError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SeismicError {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_alias(s).ok_or_else(|| format!("unknown seismic error alias: {s}"))
+    }
+}
+
+impl Serialize for SeismicError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for SeismicError {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_alias(&s).ok_or_else(|| serde::de::Error::custom(format!("unknown seismic error: {s}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_variants_roundtrip_code() {
+        for variant in SeismicError::ALL {
+            let code = variant.code();
+            let back = SeismicError::from_code(code)
+                .unwrap_or_else(|| panic!("from_code({code}) returned None"));
+            assert_eq!(*variant, back, "code round-trip failed for {code}");
+        }
+    }
+
+    #[test]
+    fn all_variants_roundtrip_str() {
+        for variant in SeismicError::ALL {
+            let s = variant.as_str();
+            let back = SeismicError::from_alias(s)
+                .unwrap_or_else(|| panic!("from_alias({s:?}) returned None"));
+            assert_eq!(*variant, back, "str round-trip failed for {s}");
+        }
+    }
+
+    #[test]
+    fn all_codes_are_seismic_range() {
+        for variant in SeismicError::ALL {
+            assert!(variant.code() >= 10000, "{:?} has code {} < 10000", variant, variant.code());
+        }
+    }
+
+    #[test]
+    fn unknown_code_returns_none() {
+        assert!(SeismicError::from_code(9999).is_none());
+        assert!(SeismicError::from_code(0).is_none());
+        assert!(SeismicError::from_code(99999).is_none());
+    }
+
+    #[test]
+    fn unknown_alias_returns_none() {
+        assert!(SeismicError::from_alias("not-a-thing").is_none());
+        assert!(SeismicError::from_alias("").is_none());
+    }
+
+    #[test]
+    fn expected_variant_count() {
+        // 11 arith/cond + 1 constructor + 5 new-expr + 5 ext-call + 5 other + 1 s-literal = 28
+        assert_eq!(SeismicError::ALL.len(), 28);
+    }
+}

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3,7 +3,8 @@
 use crate::constants::*;
 use foundry_compilers::artifacts::{ConfigurableContractArtifact, Metadata, remappings::Remapping};
 use foundry_config::{
-    BasicConfig, Chain, Config, FuzzConfig, InvariantConfig, SolidityErrorCode, parse_with_profile,
+    BasicConfig, Chain, Config, FuzzConfig, InvariantConfig, SeismicError, SolidityErrorCode,
+    parse_with_profile,
 };
 use foundry_test_utils::{
     foundry_compilers::PathStyle,
@@ -1386,9 +1387,9 @@ contract Caller {
         config.seismic = true;
         config.ignored_error_codes = vec![
             SolidityErrorCode::SpdxLicenseNotProvided,
-            SolidityErrorCode::ShieldedConstructorParam,
-            SolidityErrorCode::ShieldedLiteralNewExprInt,
-            SolidityErrorCode::ShieldedLiteralExtCallInt,
+            SolidityErrorCode::Seismic(SeismicError::ShieldedConstructorParam),
+            SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralNewExprInt),
+            SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralExtCallInt),
             // 3805 = pre-release compiler warning
             SolidityErrorCode::Other(3805),
         ];
@@ -1698,8 +1699,8 @@ forgetest!(seismic_warnings_in_tests_flag_shows_suppressed, |prj, cmd| {
             SolidityErrorCode::SpdxLicenseNotProvided,
             SolidityErrorCode::Other(3805),
             // Suppress constructor/new-expr warnings so we can isolate 10402 behavior
-            SolidityErrorCode::ShieldedConstructorParam,
-            SolidityErrorCode::ShieldedLiteralNewExprInt,
+            SolidityErrorCode::Seismic(SeismicError::ShieldedConstructorParam),
+            SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralNewExprInt),
         ];
     });
 


### PR DESCRIPTION
Introduces a dedicated `SeismicError` enum (in `crates/config/src/seismic_error.rs`) containing all 28 named seismic/ssolc warning codes, wrapped by a single `SolidityErrorCode::Seismic(SeismicError)` variant.

**Motivation** - as described in #183, adding new ssolc codes directly to `SolidityErrorCode` makes the diff against upstream foundry grow with every new code. Wrapping them in a separate type keeps `error.rs` close to upstream while still giving every code a named variant.

**Coverage** (28 variants):
- Arithmetic/branching: 10301-10311 (add, sub, mul, div, mod, exp, shl, shr, if, ternary, loop)
- Constructor param: 10103
- Literal in new-expr: 10401/10404/10407/10410/10413 (int, bool, address, fixedbytes, enum)
- Literal in ext-call: 10402/10405/10408/10411/10414
- Literal in other context: 10403/10406/10409/10412/10415
- S-literal syntax: 10416

Each variant has: string alias (for `foundry.toml`), numeric code, `from_code`/`from_alias` lookups, serde support, `Display`/`FromStr` impls, and exhaustive tests.

Closes #183