### PR TITLE
ci(release): fix prepare job 403 on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ env:
 
 jobs:
   prepare:
+    permissions:
+      contents: write
     name: Prepare release
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Adds explicit `permissions: contents: write` to the `prepare` job in the release workflow
- The `prepare` job pushes/deletes the `nightly` tag but was relying on the repo's default token permissions, which recently changed to read-only
- The `release` and `cleanup` jobs already had this permission declared; `prepare` was the only one missing it

## Test plan
- [ ] Trigger a manual workflow dispatch of the release workflow and verify the "Recreate nightly tag" step succeeds