### PR TITLE
ci: fix nightly release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,18 +56,6 @@ jobs:
             const createTag = require('./.github/scripts/create-tag.js')
             await createTag({ github, context }, process.env.TAG_NAME)
 
-      # GitHub derives the release date from the tag creation date.
-      # Delete and recreate the `nightly` tag so the release page
-      # shows today's date instead of when the tag was first created.
-      # See: https://github.com/softprops/action-gh-release/issues/171
-      - name: Recreate nightly tag
-        if: ${{ env.IS_NIGHTLY == 'true' }}
-        run: |
-          git tag -d nightly || true
-          git push origin :refs/tags/nightly || true
-          git tag nightly
-          git push origin nightly
-
       # For versioned releases (v*.*.*), find the previous semver tag to compute changelog from.
       # Unlike upstream which uses a hardcoded STABLE_VERSION env var, we resolve it dynamically
       # so we don't have to remember to update it after each release.
@@ -294,7 +282,10 @@ jobs:
           name: "Nightly"
           tag_name: "nightly"
           prerelease: true
-          body: ${{ needs.prepare.outputs.changelog }}
+          body: |
+            _The release date shown may be stale. See [${{ needs.prepare.outputs.tag_name }}](https://github.com/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.tag_name }}) for the exact build._
+
+            ${{ needs.prepare.outputs.changelog }}
           files: |
             ${{ steps.artifacts.outputs.file_name }}
             ${{ steps.artifacts.outputs.sfoundry_attestation }}


### PR DESCRIPTION
Reverting https://github.com/SeismicSystems/seismic-foundry/pull/195 and attempting another fix.

That one ended up breaking the nightly release links. Deleting and republishing the branch somehow changed the release link to `untagged-*`: https://github.com/SeismicSystems/seismic-foundry/releases/download/untagged-14a3e8012751ffb73c0d/sfoundry_nightly_darwin_arm64.tar.gz

which breaks foundryup trying to download from nightly.