### PR TITLE
chore: add lefthook configuration

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  commands:
+    fmt:
+      run: cargo +nightly fmt --all
+      stage_fixed: true
+
+pre-push:
+  commands:
+    clippy:
+      run: cargo clippy --workspace --all-targets --all-features
+    typos:
+      run: typos


### PR DESCRIPTION
## Summary
- Adds `lefthook.yml` with git hooks matching CI checks in `seismic.yml`:
  - **pre-commit**: `cargo +nightly fmt --all` (auto-formats code)
  - **pre-push**: `cargo clippy --workspace --all-targets --all-features`, `typos` spell check

## Setup
After merging, each developer needs to run `lefthook install` once in their local clone.