### PR TITLE
feat(config): name remaining seismic warning codes

### DIFF
--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -1,4 +1,5 @@
 //! error handling and solc error codes
+use crate::SeismicError;
 use alloy_primitives::map::HashSet;
 use figment::providers::{Format, Toml};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -167,9 +168,10 @@ pub enum SolidityErrorCode {
     ShieldedLiteralExtCallFixedbytes,
     /// Warning: shielded literal in external call args (enum)
     ShieldedLiteralExtCallEnum,
+    /// Named seismic/ssolc warning codes not represented as dedicated top-level variants.
+    Seismic(SeismicError),
     /// All other error codes
-    /// Note: Seismic/ssolc warning codes (>= 10000) not listed above (e.g. "other context"
-    /// 10403-10415, s-literal 10416) are handled via `Other(code)`.
+    /// Note: Unknown future seismic/ssolc warning codes still fall back to `Other(code)`.
     Other(u64),
 }
 
@@ -207,6 +209,7 @@ impl SolidityErrorCode {
             Self::ShieldedLiteralExtCallAddress => "shielded-literal-ext-call-address",
             Self::ShieldedLiteralExtCallFixedbytes => "shielded-literal-ext-call-fixedbytes",
             Self::ShieldedLiteralExtCallEnum => "shielded-literal-ext-call-enum",
+            Self::Seismic(error) => error.as_str(),
             Self::Other(code) => return Err(*code),
         };
         Ok(s)
@@ -244,6 +247,7 @@ impl From<SolidityErrorCode> for u64 {
             SolidityErrorCode::ShieldedLiteralExtCallAddress => 10408,
             SolidityErrorCode::ShieldedLiteralExtCallFixedbytes => 10411,
             SolidityErrorCode::ShieldedLiteralExtCallEnum => 10414,
+            SolidityErrorCode::Seismic(error) => error.into(),
             SolidityErrorCode::Other(code) => code,
         }
     }
@@ -291,7 +295,11 @@ impl FromStr for SolidityErrorCode {
             "shielded-literal-ext-call-address" => Self::ShieldedLiteralExtCallAddress,
             "shielded-literal-ext-call-fixedbytes" => Self::ShieldedLiteralExtCallFixedbytes,
             "shielded-literal-ext-call-enum" => Self::ShieldedLiteralExtCallEnum,
-            _ => return Err(format!("Unknown variant {s}")),
+            _ => {
+                return SeismicError::from_str(s)
+                    .map(Self::Seismic)
+                    .map_err(|_| format!("Unknown variant {s}"))
+            }
         };
 
         Ok(code)
@@ -329,7 +337,9 @@ impl From<u64> for SolidityErrorCode {
             10408 => Self::ShieldedLiteralExtCallAddress,
             10411 => Self::ShieldedLiteralExtCallFixedbytes,
             10414 => Self::ShieldedLiteralExtCallEnum,
-            other => Self::Other(other),
+            other => {
+                SeismicError::from_code(other).map(Self::Seismic).unwrap_or(Self::Other(other))
+            }
         }
     }
 }
@@ -395,6 +405,91 @@ mod tests {
             "shielded-literal-ext-call-fixedbytes",
         ),
         (SolidityErrorCode::ShieldedLiteralExtCallEnum, 10414, "shielded-literal-ext-call-enum"),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralOtherInt),
+            10403,
+            "shielded-literal-other-int",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralOtherBool),
+            10406,
+            "shielded-literal-other-bool",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralOtherAddress),
+            10409,
+            "shielded-literal-other-address",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralOtherFixedbytes),
+            10412,
+            "shielded-literal-other-fixedbytes",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralOtherEnum),
+            10415,
+            "shielded-literal-other-enum",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedNumberLiteral),
+            10416,
+            "shielded-number-literal",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticAddition),
+            10301,
+            "shielded-arithmetic-addition",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticSubtraction),
+            10302,
+            "shielded-arithmetic-subtraction",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticMultiplication),
+            10303,
+            "shielded-arithmetic-multiplication",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticDivision),
+            10304,
+            "shielded-arithmetic-division",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticModulo),
+            10305,
+            "shielded-arithmetic-modulo",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticExponentiation),
+            10306,
+            "shielded-arithmetic-exponentiation",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticShiftLeft),
+            10307,
+            "shielded-arithmetic-shift-left",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticShiftRight),
+            10308,
+            "shielded-arithmetic-shift-right",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedBranchingIfCondition),
+            10309,
+            "shielded-branching-if-condition",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedBranchingTernaryCondition),
+            10310,
+            "shielded-branching-ternary-condition",
+        ),
+        (
+            SolidityErrorCode::Seismic(SeismicError::ShieldedBranchingWhileForCondition),
+            10311,
+            "shielded-branching-while-for-condition",
+        ),
     ];
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -98,6 +98,9 @@ pub use warning::*;
 
 pub mod fix;
 
+mod seismic_error;
+pub use seismic_error::SeismicError;
+
 // reexport so cli types can implement `figment::Provider` to easily merge compiler arguments
 pub use alloy_chains::{Chain, NamedChain};
 pub use figment;
@@ -4992,7 +4995,7 @@ mod tests {
                 "foundry.toml",
                 r#"
                 [default]
-                ignored_error_codes = ["license", "unreachable", 1337]
+                ignored_error_codes = ["license", "unreachable", "shielded-literal-other-int", "shielded-number-literal", "shielded-arithmetic-addition", 1337]
             "#,
             )?;
 
@@ -5002,6 +5005,9 @@ mod tests {
                 vec![
                     SolidityErrorCode::SpdxLicenseNotProvided,
                     SolidityErrorCode::Unreachable,
+                    SolidityErrorCode::Seismic(SeismicError::ShieldedLiteralOtherInt),
+                    SolidityErrorCode::Seismic(SeismicError::ShieldedNumberLiteral),
+                    SolidityErrorCode::Seismic(SeismicError::ShieldedArithmeticAddition),
                     SolidityErrorCode::Other(1337)
                 ]
             );

--- a/crates/config/src/seismic_error.rs
+++ b/crates/config/src/seismic_error.rs
@@ -1,0 +1,147 @@
+use std::{fmt, str::FromStr};
+
+/// Named seismic/ssolc warning codes that are not represented as top-level
+/// `SolidityErrorCode` variants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SeismicError {
+    /// Warning: shielded literal in other contexts (int)
+    ShieldedLiteralOtherInt,
+    /// Warning: shielded literal in other contexts (bool)
+    ShieldedLiteralOtherBool,
+    /// Warning: shielded literal in other contexts (address)
+    ShieldedLiteralOtherAddress,
+    /// Warning: shielded literal in other contexts (fixedbytes)
+    ShieldedLiteralOtherFixedbytes,
+    /// Warning: shielded literal in other contexts (enum)
+    ShieldedLiteralOtherEnum,
+    /// Warning: shielded number literal syntax (e.g. `5s`)
+    ShieldedNumberLiteral,
+    /// Warning: shielded arithmetic in addition
+    ShieldedArithmeticAddition,
+    /// Warning: shielded arithmetic in subtraction
+    ShieldedArithmeticSubtraction,
+    /// Warning: shielded arithmetic in multiplication
+    ShieldedArithmeticMultiplication,
+    /// Warning: shielded arithmetic in division
+    ShieldedArithmeticDivision,
+    /// Warning: shielded arithmetic in modulo
+    ShieldedArithmeticModulo,
+    /// Warning: shielded arithmetic in exponentiation
+    ShieldedArithmeticExponentiation,
+    /// Warning: shielded arithmetic in shift left
+    ShieldedArithmeticShiftLeft,
+    /// Warning: shielded arithmetic in shift right
+    ShieldedArithmeticShiftRight,
+    /// Warning: shielded branching in if conditions
+    ShieldedBranchingIfCondition,
+    /// Warning: shielded branching in ternary conditions
+    ShieldedBranchingTernaryCondition,
+    /// Warning: shielded branching in while/for conditions
+    ShieldedBranchingWhileForCondition,
+}
+
+impl SeismicError {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ShieldedLiteralOtherInt => "shielded-literal-other-int",
+            Self::ShieldedLiteralOtherBool => "shielded-literal-other-bool",
+            Self::ShieldedLiteralOtherAddress => "shielded-literal-other-address",
+            Self::ShieldedLiteralOtherFixedbytes => "shielded-literal-other-fixedbytes",
+            Self::ShieldedLiteralOtherEnum => "shielded-literal-other-enum",
+            Self::ShieldedNumberLiteral => "shielded-number-literal",
+            Self::ShieldedArithmeticAddition => "shielded-arithmetic-addition",
+            Self::ShieldedArithmeticSubtraction => "shielded-arithmetic-subtraction",
+            Self::ShieldedArithmeticMultiplication => "shielded-arithmetic-multiplication",
+            Self::ShieldedArithmeticDivision => "shielded-arithmetic-division",
+            Self::ShieldedArithmeticModulo => "shielded-arithmetic-modulo",
+            Self::ShieldedArithmeticExponentiation => "shielded-arithmetic-exponentiation",
+            Self::ShieldedArithmeticShiftLeft => "shielded-arithmetic-shift-left",
+            Self::ShieldedArithmeticShiftRight => "shielded-arithmetic-shift-right",
+            Self::ShieldedBranchingIfCondition => "shielded-branching-if-condition",
+            Self::ShieldedBranchingTernaryCondition => "shielded-branching-ternary-condition",
+            Self::ShieldedBranchingWhileForCondition => "shielded-branching-while-for-condition",
+        }
+    }
+
+    pub fn from_code(code: u64) -> Option<Self> {
+        match code {
+            10403 => Some(Self::ShieldedLiteralOtherInt),
+            10406 => Some(Self::ShieldedLiteralOtherBool),
+            10409 => Some(Self::ShieldedLiteralOtherAddress),
+            10412 => Some(Self::ShieldedLiteralOtherFixedbytes),
+            10415 => Some(Self::ShieldedLiteralOtherEnum),
+            10416 => Some(Self::ShieldedNumberLiteral),
+            10301 => Some(Self::ShieldedArithmeticAddition),
+            10302 => Some(Self::ShieldedArithmeticSubtraction),
+            10303 => Some(Self::ShieldedArithmeticMultiplication),
+            10304 => Some(Self::ShieldedArithmeticDivision),
+            10305 => Some(Self::ShieldedArithmeticModulo),
+            10306 => Some(Self::ShieldedArithmeticExponentiation),
+            10307 => Some(Self::ShieldedArithmeticShiftLeft),
+            10308 => Some(Self::ShieldedArithmeticShiftRight),
+            10309 => Some(Self::ShieldedBranchingIfCondition),
+            10310 => Some(Self::ShieldedBranchingTernaryCondition),
+            10311 => Some(Self::ShieldedBranchingWhileForCondition),
+            _ => None,
+        }
+    }
+}
+
+impl From<SeismicError> for u64 {
+    fn from(error: SeismicError) -> Self {
+        match error {
+            SeismicError::ShieldedLiteralOtherInt => 10403,
+            SeismicError::ShieldedLiteralOtherBool => 10406,
+            SeismicError::ShieldedLiteralOtherAddress => 10409,
+            SeismicError::ShieldedLiteralOtherFixedbytes => 10412,
+            SeismicError::ShieldedLiteralOtherEnum => 10415,
+            SeismicError::ShieldedNumberLiteral => 10416,
+            SeismicError::ShieldedArithmeticAddition => 10301,
+            SeismicError::ShieldedArithmeticSubtraction => 10302,
+            SeismicError::ShieldedArithmeticMultiplication => 10303,
+            SeismicError::ShieldedArithmeticDivision => 10304,
+            SeismicError::ShieldedArithmeticModulo => 10305,
+            SeismicError::ShieldedArithmeticExponentiation => 10306,
+            SeismicError::ShieldedArithmeticShiftLeft => 10307,
+            SeismicError::ShieldedArithmeticShiftRight => 10308,
+            SeismicError::ShieldedBranchingIfCondition => 10309,
+            SeismicError::ShieldedBranchingTernaryCondition => 10310,
+            SeismicError::ShieldedBranchingWhileForCondition => 10311,
+        }
+    }
+}
+
+impl fmt::Display for SeismicError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl FromStr for SeismicError {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "shielded-literal-other-int" => Ok(Self::ShieldedLiteralOtherInt),
+            "shielded-literal-other-bool" => Ok(Self::ShieldedLiteralOtherBool),
+            "shielded-literal-other-address" => Ok(Self::ShieldedLiteralOtherAddress),
+            "shielded-literal-other-fixedbytes" => Ok(Self::ShieldedLiteralOtherFixedbytes),
+            "shielded-literal-other-enum" => Ok(Self::ShieldedLiteralOtherEnum),
+            "shielded-number-literal" => Ok(Self::ShieldedNumberLiteral),
+            "shielded-arithmetic-addition" => Ok(Self::ShieldedArithmeticAddition),
+            "shielded-arithmetic-subtraction" => Ok(Self::ShieldedArithmeticSubtraction),
+            "shielded-arithmetic-multiplication" => Ok(Self::ShieldedArithmeticMultiplication),
+            "shielded-arithmetic-division" => Ok(Self::ShieldedArithmeticDivision),
+            "shielded-arithmetic-modulo" => Ok(Self::ShieldedArithmeticModulo),
+            "shielded-arithmetic-exponentiation" => Ok(Self::ShieldedArithmeticExponentiation),
+            "shielded-arithmetic-shift-left" => Ok(Self::ShieldedArithmeticShiftLeft),
+            "shielded-arithmetic-shift-right" => Ok(Self::ShieldedArithmeticShiftRight),
+            "shielded-branching-if-condition" => Ok(Self::ShieldedBranchingIfCondition),
+            "shielded-branching-ternary-condition" => Ok(Self::ShieldedBranchingTernaryCondition),
+            "shielded-branching-while-for-condition" => {
+                Ok(Self::ShieldedBranchingWhileForCondition)
+            }
+            _ => Err(format!("Unknown seismic variant {s}")),
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

`SolidityErrorCode` already exposes named aliases for part of Seismic's warning surface, but the remaining seismic/ssolc warnings still fall back to `Other(code)`.

That makes them impossible to reference by name in `foundry.toml`, which is the gap called out in #183.

## Solution

This change adds named handling for the remaining seismic warning codes while keeping the existing top-level variants unchanged:

- introduces a dedicated `SeismicError` enum for the previously unnamed seismic/ssolc warnings
- adds `SolidityErrorCode::Seismic(SeismicError)` for those codes
- wires the new variants through `as_str`, `From<u64>`, `Into<u64>`, and `FromStr`
- extends the existing shielded warning conversion tests
- updates config parsing coverage so the new aliases can be used in `ignored_error_codes`

For the `10301..10311` arithmetic/branching warnings, the new aliases follow the wording from #183 directly.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Closes #183.