### PR TITLE
fix(anvil): reject signed reads at decode time (Veridise 1083)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=c8fad0b93da53f2b423d2f6720abdb4a6cbb9082#c8fad0b93da53f2b423d2f6720abdb4a6cbb9082"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=c8fad0b93da53f2b423d2f6720abdb4a6cbb9082#c8fad0b93da53f2b423d2f6720abdb4a6cbb9082"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -9457,6 +9457,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rlp",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -9476,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=c8fad0b93da53f2b423d2f6720abdb4a6cbb9082#c8fad0b93da53f2b423d2f6720abdb4a6cbb9082"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -9497,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=c8fad0b93da53f2b423d2f6720abdb4a6cbb9082#c8fad0b93da53f2b423d2f6720abdb4a6cbb9082"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9532,7 +9533,7 @@ dependencies = [
 [[package]]
 name = "seismic-prelude"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=c8fad0b93da53f2b423d2f6720abdb4a6cbb9082#c8fad0b93da53f2b423d2f6720abdb4a6cbb9082"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,11 +400,11 @@ seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "025bdf5924af5aa966c5b349f1f11a6d3e547fa4" }
 
 # seismic-alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c8fad0b93da53f2b423d2f6720abdb4a6cbb9082" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c8fad0b93da53f2b423d2f6720abdb4a6cbb9082" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c8fad0b93da53f2b423d2f6720abdb4a6cbb9082" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c8fad0b93da53f2b423d2f6720abdb4a6cbb9082" }
-seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c8fad0b93da53f2b423d2f6720abdb4a6cbb9082" }
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
+seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
 
 # alloy-evm
 alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "c33f3076495d153eefbde07dd81c3a575f3d19b8" }

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1196,16 +1196,20 @@ impl alloy_eips::eip2718::Encodable2718 for TypedTransaction {
     }
 }
 
-impl alloy_eips::eip2718::Decodable2718 for TypedTransaction {
-    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Result<Self, alloy_eips::eip2718::Eip2718Error> {
+impl TypedTransaction {
+    /// Shared EIP-2718 typed-decode body. When `reject_signed_reads` is `true`, a seismic tx
+    /// carrying `signed_read = true` is rejected at decode time: signed reads are an RPC
+    /// `eth_call`-only construct, and admitting one as a state transition (call or create) would
+    /// let an attacker replay an intercepted signed `eth_call` payload as a real write. Mirrors
+    /// reth's consensus `SeismicTransactionSigned::typed_decode` for dev/prod parity.
+    fn typed_decode_inner(
+        ty: u8,
+        buf: &mut &[u8],
+        reject_signed_reads: bool,
+    ) -> Result<Self, Eip2718Error> {
         if ty == SEISMIC_TX_TYPE_ID {
             let tx = Signed::<TxSeismic>::rlp_decode(buf)?;
-            // Reject every signed-read seismic tx at decode time. Signed reads are an RPC
-            // `eth_call`-only construct; admitting one as a state transition (call or create) would
-            // let an attacker replay an intercepted signed `eth_call` payload as a real write. This
-            // is sanvil's (dev-tool) decoder, gated for dev/prod parity with the same guard in
-            // reth's consensus `SeismicTransactionSigned::typed_decode`.
-            if tx.tx().seismic_elements.signed_read {
+            if reject_signed_reads && tx.tx().seismic_elements.signed_read {
                 return Err(alloy_rlp::Error::Custom(
                     "signed-read seismic transactions cannot appear in blocks or the mempool",
                 )
@@ -1223,6 +1227,25 @@ impl alloy_eips::eip2718::Decodable2718 for TypedTransaction {
             TxEnvelope::Eip7702(tx) => Ok(Self::EIP7702(tx)),
             _ => Err(Eip2718Error::RlpError(alloy_rlp::Error::Custom("unexpected tx type"))),
         }
+    }
+
+    /// Permissive EIP-2718 decode for the RPC `eth_call` / `eth_estimateGas` bytes path, which
+    /// legitimately accepts signed-read seismic txs. Block / mempool / `eth_sendRawTransaction`
+    /// ingress must use the strict [`Decodable2718::decode_2718`], which rejects them.
+    pub fn decode_2718_permit_seismic_calls(buf: &mut &[u8]) -> Result<Self, Eip2718Error> {
+        match Self::extract_type_byte(buf) {
+            Some(ty) => {
+                *buf = &buf[1..];
+                Self::typed_decode_inner(ty, buf, false)
+            }
+            None => Self::fallback_decode(buf),
+        }
+    }
+}
+
+impl alloy_eips::eip2718::Decodable2718 for TypedTransaction {
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Result<Self, alloy_eips::eip2718::Eip2718Error> {
+        Self::typed_decode_inner(ty, buf, true)
     }
 
     fn fallback_decode(buf: &mut &[u8]) -> Result<Self, alloy_eips::eip2718::Eip2718Error> {
@@ -2076,5 +2099,14 @@ mod tests {
         let encoded = encoded_seismic_tx(false, TxKind::Call(Address::with_last_byte(1)));
         TypedTransaction::decode_2718(&mut &encoded[..])
             .expect("non-signed-read seismic write must decode");
+    }
+
+    /// The permissive decoder (eth_call / estimateGas bytes path) must accept a signed read —
+    /// the strict `decode_2718` rejects it; this is the legitimate counterpart.
+    #[test]
+    fn permissive_decode_accepts_signed_read() {
+        let encoded = encoded_seismic_tx(true, TxKind::Call(Address::with_last_byte(1)));
+        TypedTransaction::decode_2718_permit_seismic_calls(&mut &encoded[..])
+            .expect("permissive decode must accept signed-read seismic tx");
     }
 }

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1199,7 +1199,19 @@ impl alloy_eips::eip2718::Encodable2718 for TypedTransaction {
 impl alloy_eips::eip2718::Decodable2718 for TypedTransaction {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Result<Self, alloy_eips::eip2718::Eip2718Error> {
         if ty == SEISMIC_TX_TYPE_ID {
-            return Ok(Self::Seismic(Signed::<TxSeismic>::rlp_decode(buf)?));
+            let tx = Signed::<TxSeismic>::rlp_decode(buf)?;
+            // Reject every signed-read seismic tx at decode time. Signed reads are an RPC
+            // `eth_call`-only construct; admitting one as a state transition (call or create) would
+            // let an attacker replay an intercepted signed `eth_call` payload as a real write. This
+            // is sanvil's (dev-tool) decoder, gated for dev/prod parity with the same guard in
+            // reth's consensus `SeismicTransactionSigned::typed_decode`.
+            if tx.tx().seismic_elements.signed_read {
+                return Err(alloy_rlp::Error::Custom(
+                    "signed-read seismic transactions cannot appear in blocks or the mempool",
+                )
+                .into());
+            }
+            return Ok(Self::Seismic(tx));
         }
         if ty == 0x7E {
             return Ok(Self::Deposit(TxDeposit::decode(buf)?));
@@ -2005,5 +2017,64 @@ mod tests {
         let decoded_tx = TypedTransaction::decode(&mut buf).unwrap();
 
         assert_eq!(decoded_tx, signed_tt);
+    }
+
+    /// Build the EIP-2718 bytes of a signed seismic tx with the given `signed_read`/`to`.
+    /// The signature is arbitrary: the decoder gates on `signed_read` before any recovery,
+    /// so a dummy signature exercises the path we care about.
+    fn encoded_seismic_tx(signed_read: bool, to: TxKind) -> Vec<u8> {
+        let tx = TxSeismic {
+            chain_id: 31337u64,
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to,
+            value: U256::ZERO,
+            input: Bytes::new(),
+            seismic_elements: TxSeismicElements {
+                encryption_pubkey: get_unsecure_sample_secp256k1_pk(),
+                encryption_nonce: U96::ZERO,
+                message_version: 0,
+                recent_block_hash: B256::ZERO,
+                expires_at_block: 1,
+                signed_read,
+            },
+            authorization_list: vec![],
+        };
+        let signature = Signature::new(U256::from(1u64), U256::from(1u64), false);
+        let signed_tt = TypedTransaction::Seismic(tx.into_signed(signature));
+        let mut buf = Vec::new();
+        signed_tt.encode_2718(&mut buf);
+        buf
+    }
+
+    /// The sanvil decoder must reject a signed-read seismic call tx, matching reth's
+    /// consensus-decoder gate, so a replayed signed `eth_call` can't enter a block/mempool.
+    #[test]
+    fn decode_2718_rejects_signed_read_write() {
+        let encoded = encoded_seismic_tx(true, TxKind::Call(Address::with_last_byte(1)));
+        assert!(
+            TypedTransaction::decode_2718(&mut &encoded[..]).is_err(),
+            "sanvil decoder must reject signed-read seismic call tx"
+        );
+    }
+
+    /// A signed-read create is rejected too: a create is also a state transition, so there's no
+    /// legitimate signed-read create on a block/mempool ingress path.
+    #[test]
+    fn decode_2718_rejects_signed_read_create() {
+        let encoded = encoded_seismic_tx(true, TxKind::Create);
+        assert!(
+            TypedTransaction::decode_2718(&mut &encoded[..]).is_err(),
+            "sanvil decoder must reject signed-read seismic create tx"
+        );
+    }
+
+    /// Ordinary (non-signed-read) seismic writes must still decode unaffected.
+    #[test]
+    fn decode_2718_accepts_non_signed_read_write() {
+        let encoded = encoded_seismic_tx(false, TxKind::Call(Address::with_last_byte(1)));
+        TypedTransaction::decode_2718(&mut &encoded[..])
+            .expect("non-signed-read seismic write must decode");
     }
 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3167,8 +3167,13 @@ impl EthApi {
                     ))
                 })?
             }
-            SeismicCallRequest::Bytes(bytes) => TypedTransaction::decode_2718(&mut bytes.as_ref())
-                .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?,
+            SeismicCallRequest::Bytes(bytes) => {
+                // eth_call / estimateGas legitimately accept signed-read seismic txs, so decode
+                // permissively here. Tx/block ingress uses the strict `decode_2718`, which rejects
+                // signed reads to prevent replay-as-write.
+                TypedTransaction::decode_2718_permit_seismic_calls(&mut bytes.as_ref())
+                    .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?
+            }
             SeismicCallRequest::TransactionRequest(_) => {
                 return Err(BlockchainError::Message(
                     "Expected signed request (TypedData or Bytes)".to_string(),

--- a/crates/anvil/tests/it/seismic.rs
+++ b/crates/anvil/tests/it/seismic.rs
@@ -755,7 +755,7 @@ async fn test_seismic_precompiles_end_to_end() {
 // Seismic testnet instead, verifying that sanvil can fork a Seismic chain.
 
 /// Seismic testnet RPC endpoint for fork tests.
-const SEISMIC_TESTNET_RPC: &str = "https://gcp-0.seismictest.net/rpc";
+const SEISMIC_TESTNET_RPC: &str = "https://testnet-1.seismictest.net/rpc";
 /// Chain ID of the Seismic testnet.
 const SEISMIC_TESTNET_CHAIN_ID: u64 = 5124;
 /// Block number to fork from in fork tests (early block to minimize RPC data).

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -277,7 +277,7 @@ impl MultiForkHandler {
     }
 
     /// Returns the list of additional senders of a matching task for the given id, if any.
-    #[expect(irrefutable_let_patterns)]
+    #[allow(irrefutable_let_patterns)]
     fn find_in_progress_task(&mut self, id: &ForkId) -> Option<&mut Vec<CreateSender>> {
         for task in &mut self.pending_tasks {
             if let ForkTask::Create(_, in_progress, _, additional) = task


### PR DESCRIPTION
Signed-read seismic txs are an RPC `eth_call`-only construct and must never be executed as a state transition. Admitting one as a real tx lets an attacker who intercepted a signed `eth_call` payload replay it as a state-changing write.

sanvil decoded seismic txs from the wire without enforcing this. Gate anvil's `TypedTransaction::typed_decode` to reject any signed-read seismic tx at decode time, regardless of `to` (a create is also a state transition, so there is no legitimate signed-read create). This mirrors reth's consensus-decoder guard (`SeismicTransactionSigned::typed_decode`) for dev/prod parity.

The `eth_call` / `eth_estimateGas` / `seismic_call` bytes path is the one place signed reads are *legitimate*, so it decodes through a separate permissive entry point, `TypedTransaction::decode_2718_permit_seismic_calls`, which skips the gate. Transaction/block ingress (`eth_sendRawTransaction`, raw-tx→pool) uses the strict `decode_2718`. This is the same strict/permissive split as reth/seismic-alloy's `decode_2718_permit_seismic_calls`, and the explicit function name keeps the security trade-off visible at the call site.

Also bump seismic-alloy to `7545c3b` (merged SeismicSystems/seismic-alloy#104), which gates the seismic-alloy decoders sanvil depends on — the `SeismicFoundryTxEnvelope` network decoder and the tightened `SeismicTxEnvelope` — so signed reads are rejected on every seismic-alloy + anvil EIP-2718 ingress path and accepted only on the call path.

Add regression tests: reject signed-read call, reject signed-read create, accept non-signed-read, and accept a signed read on the permissive call decoder.