### PR TITLE
add verbose-json-rpc flag

### DIFF
--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -47,6 +47,10 @@ pub struct GlobalArgs {
     /// Number of threads to use. Specifying 0 defaults to the number of logical cores.
     #[arg(global = true, long, short = 'j', visible_alias = "jobs")]
     threads: Option<usize>,
+
+    /// Print every JSON-RPC request and response to stderr.
+    #[arg(help_heading = "Display options", global = true, long)]
+    verbose_json_rpc: bool,
 }
 
 impl GlobalArgs {
@@ -54,6 +58,11 @@ impl GlobalArgs {
     pub fn init(&self) -> eyre::Result<()> {
         // Set the global shell.
         self.shell().set();
+
+        // Enable JSON-RPC request/response logging on the provider transport.
+        if self.verbose_json_rpc {
+            foundry_common::provider::json_rpc_logging::set_verbose_json_rpc(true);
+        }
 
         // Initialize the thread pool only if `threads` was requested to avoid unnecessary overhead.
         if self.threads.is_some() {

--- a/crates/common/src/provider/json_rpc_logging.rs
+++ b/crates/common/src/provider/json_rpc_logging.rs
@@ -1,0 +1,113 @@
+//! A transport layer that prints full JSON-RPC requests and responses to stderr.
+//!
+//! The layer is always installed in the provider stack but is a no-op unless
+//! enabled via [`set_verbose_json_rpc`] (wired to the global `--verbose-json-rpc`
+//! CLI flag). It sits below the retry layer, so retried requests are printed as
+//! they appear on the wire.
+
+use alloy_json_rpc::{RequestPacket, ResponsePacket};
+use alloy_transport::{TransportError, TransportFut};
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
+
+static VERBOSE_JSON_RPC: AtomicBool = AtomicBool::new(false);
+
+/// Enables or disables printing of JSON-RPC requests and responses.
+pub fn set_verbose_json_rpc(enabled: bool) {
+    VERBOSE_JSON_RPC.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether printing of JSON-RPC requests and responses is enabled.
+pub fn verbose_json_rpc() -> bool {
+    VERBOSE_JSON_RPC.load(Ordering::Relaxed)
+}
+
+/// A transport layer that prints every JSON-RPC request and response to stderr
+/// when enabled via [`set_verbose_json_rpc`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct JsonRpcLoggingLayer;
+
+impl<S> Layer<S> for JsonRpcLoggingLayer {
+    type Service = JsonRpcLoggingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        JsonRpcLoggingService { inner }
+    }
+}
+
+/// Tower service for [`JsonRpcLoggingLayer`].
+#[derive(Clone, Debug)]
+pub struct JsonRpcLoggingService<S> {
+    inner: S,
+}
+
+impl<S> Service<RequestPacket> for JsonRpcLoggingService<S>
+where
+    S: Service<
+            RequestPacket,
+            Response = ResponsePacket,
+            Error = TransportError,
+            Future = TransportFut<'static>,
+        >
+        + Send
+        + 'static
+        + Clone,
+{
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        if !verbose_json_rpc() {
+            return self.inner.call(req);
+        }
+
+        print_request(&req);
+        let fut = self.inner.call(req);
+        Box::pin(async move {
+            let resp = fut.await;
+            match &resp {
+                Ok(resp) => print_response(resp),
+                Err(err) => {
+                    let _ = sh_eprintln!("JSON-RPC error:\n{err}");
+                }
+            }
+            resp
+        })
+    }
+}
+
+fn print_request(req: &RequestPacket) {
+    match req {
+        RequestPacket::Single(req) => {
+            let _ = sh_eprintln!("JSON-RPC request:\n{}", req.serialized().get());
+        }
+        RequestPacket::Batch(reqs) => {
+            for req in reqs {
+                let _ = sh_eprintln!("JSON-RPC batch request:\n{}", req.serialized().get());
+            }
+        }
+    }
+}
+
+fn print_response(resp: &ResponsePacket) {
+    let json = match resp {
+        ResponsePacket::Single(resp) => serde_json::to_string_pretty(resp),
+        ResponsePacket::Batch(resps) => serde_json::to_string_pretty(resps),
+    };
+    match json {
+        Ok(json) => {
+            let _ = sh_eprintln!("JSON-RPC response:\n{json}");
+        }
+        Err(e) => {
+            let _ = sh_eprintln!("JSON-RPC response: <failed to serialize: {e}>");
+        }
+    }
+}

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -1,9 +1,11 @@
 //! Provider-related instantiation and usage utilities.
 
+pub mod json_rpc_logging;
 pub mod runtime_transport;
 
 use crate::{
-    ALCHEMY_FREE_TIER_CUPS, REQUEST_TIMEOUT, provider::runtime_transport::RuntimeTransportBuilder,
+    ALCHEMY_FREE_TIER_CUPS, REQUEST_TIMEOUT,
+    provider::{json_rpc_logging::JsonRpcLoggingLayer, runtime_transport::RuntimeTransportBuilder},
 };
 use alloy_provider::{
     ProviderBuilder as AlloyProviderBuilder, RootProvider,
@@ -296,7 +298,10 @@ impl ProviderBuilder {
             .with_jwt(jwt)
             .accept_invalid_certs(accept_invalid_certs)
             .build();
-        let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
+        let client = ClientBuilder::default()
+            .layer(retry_layer)
+            .layer(JsonRpcLoggingLayer)
+            .transport(transport, is_local);
 
         if !is_local {
             client.set_poll_interval(
@@ -342,7 +347,10 @@ impl ProviderBuilder {
             .accept_invalid_certs(accept_invalid_certs)
             .build();
 
-        let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
+        let client = ClientBuilder::default()
+            .layer(retry_layer)
+            .layer(JsonRpcLoggingLayer)
+            .transport(transport, is_local);
 
         if !is_local {
             client.set_poll_interval(


### PR DESCRIPTION
added global flag --verbose-json-rpc. A global debugging flag that mirrors all JSON-RPC traffic between the CLI and the node.  For each RPC round-trip it prints two blocks:
- JSON-RPC request: followed by the request exactly as sent on the wire — {"method":"eth_call","params":[...],"id":5,"jsonrpc":"2.0"}
- JSON-RPC response: followed by the node's full reply, pretty-printed

Output goes to stderr so piping stdout still works fine (scast call ... --json | jq)