### PR TITLE
feat: estimate gas via signed reads for forge create

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,7 +60,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model claude-sonnet-4-20250514
+            --model claude-sonnet-5
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
           prompt: |
             Review PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,6 +4604,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-abi",
  "alloy-json-rpc",
+ "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ literal-string-with-formatting-args = "allow"
 result_large_err = "allow"
 
 [workspace.lints.rust]
+# eyre 0.6's bail!/ensure! expand with a trailing semicolon, which newer rustc
+# denies in expression position (rust-lang/rust#79813). Remove this allow once
+# eyre ships a fix or the lint becomes a hard error (then call sites need braces).
+semicolon_in_expressions_from_macros = "allow"
 redundant_imports = "warn"
 redundant-lifetimes = "warn"
 rust-2018-idioms = "warn"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "foundry-bench"
 path = "src/main.rs"

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -57,7 +57,7 @@ impl FromStr for RepoConfig {
         } else {
             // Create new config with custom rev or default
             // Name should follow the format: org-repo (with hyphen)
-            RepoConfig {
+            Self {
                 name: format!("{org}-{repo}"),
                 org: org.to_string(),
                 repo: repo.to_string(),
@@ -159,7 +159,7 @@ impl BenchmarkProject {
         Self::install_npm_dependencies(&root_path)?;
 
         sh_println!("  ✅ Project {} setup complete at {}", config.name, root);
-        Ok(BenchmarkProject { name: config.name.to_string(), root_path, temp_project })
+        Ok(Self { name: config.name.to_string(), root_path, temp_project })
     }
 
     /// Install npm dependencies if package.json exists

--- a/crates/cast/src/cmd/seismic_utils.rs
+++ b/crates/cast/src/cmd/seismic_utils.rs
@@ -1,8 +1,8 @@
 //! Shared utilities for seismic transaction encryption in scast commands.
 
 use alloy_consensus::BlockHeader;
-use alloy_network::{TransactionBuilder, eip2718::Encodable2718};
-use alloy_primitives::{Bytes, U256, aliases::U96};
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Bytes, aliases::U96};
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockNumberOrTag;
 use alloy_serde::WithOtherFields;
@@ -102,24 +102,7 @@ pub fn encrypt_tx_input(
     Ok(())
 }
 
-/// Sign the tx and send raw bytes to eth_estimateGas, returning the estimate.
-/// The tx's gas limit should already be set (signed reads require a fully
-/// formed tx, so estimation itself needs a gas limit to sign with).
-pub async fn request_signed_gas_estimate<P: Provider<AnyNetwork>>(
-    provider: &P,
-    tx: &WithOtherFields<TransactionRequest>,
-    wallet: &EthereumWallet,
-) -> Result<u64> {
-    let signed = tx
-        .clone()
-        .build(wallet)
-        .await
-        .map_err(|e| eyre::eyre!("Failed to sign tx for gas estimation: {e:?}"))?;
-    let encoded = Bytes::from(signed.encoded_2718());
-
-    let gas = provider.client().request::<_, U256>("eth_estimateGas", (encoded,)).await?;
-    gas.try_into().map_err(|_| eyre::eyre!("Gas estimate exceeds u64::MAX"))
-}
+pub use foundry_common::seismic::request_signed_gas_estimate;
 
 /// Sign the tx and send raw bytes to eth_estimateGas.
 /// Falls back to `block_gas_limit` if estimation fails.

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -24,6 +24,7 @@ alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-eips.workspace = true
 alloy-json-abi.workspace = true
 alloy-json-rpc.workspace = true
+alloy-network.workspace = true
 alloy-primitives = { workspace = true, features = [
     "serde",
     "getrandom",

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -30,6 +30,7 @@ pub mod mapping_slots;
 mod preprocessor;
 pub mod provider;
 pub mod retry;
+pub mod seismic;
 pub mod selectors;
 pub mod serde_helpers;
 pub mod slot_identifier;

--- a/crates/common/src/seismic.rs
+++ b/crates/common/src/seismic.rs
@@ -1,0 +1,34 @@
+//! Seismic-specific helpers shared across foundry tools.
+
+use alloy_network::{TransactionBuilder, eip2718::Encodable2718};
+use alloy_primitives::{Bytes, U256};
+use alloy_provider::Provider;
+use alloy_serde::WithOtherFields;
+use eyre::Result;
+use seismic_prelude::foundry::{AnyNetwork, EthereumWallet, TransactionRequest};
+
+/// Sign the tx and send raw bytes to eth_estimateGas, returning the estimate.
+///
+/// The node sanitizes unsigned `eth_estimateGas` requests (clearing `from` to
+/// prevent sender spoofing), which underprices any tx whose gas depends on
+/// `msg.sender`. Raw signed bytes authenticate the sender cryptographically,
+/// so the estimate runs against the real sender. Works for all tx types, not
+/// just seismic ones.
+///
+/// The tx's gas limit should already be set (signing requires a fully formed
+/// tx, so estimation itself needs a placeholder gas limit to sign with).
+pub async fn request_signed_gas_estimate<P: Provider<AnyNetwork>>(
+    provider: &P,
+    tx: &WithOtherFields<TransactionRequest>,
+    wallet: &EthereumWallet,
+) -> Result<u64> {
+    let signed = tx
+        .clone()
+        .build(wallet)
+        .await
+        .map_err(|e| eyre::eyre!("Failed to sign tx for gas estimation: {e:?}"))?;
+    let encoded = Bytes::from(signed.encoded_2718());
+
+    let gas = provider.client().request::<_, U256>("eth_estimateGas", (encoded,)).await?;
+    gas.try_into().map_err(|_| eyre::eyre!("Gas estimate exceeds u64::MAX"))
+}

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -5,6 +5,7 @@ use alloy_json_abi::{Constructor, JsonAbi};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, Bytes, hex};
 use alloy_provider::{PendingTransactionError, Provider, ProviderBuilder};
+use alloy_rpc_types::BlockNumberOrTag;
 use alloy_serde::WithOtherFields;
 use alloy_signer::Signer;
 use alloy_transport::TransportError;
@@ -182,15 +183,22 @@ impl CreateArgs {
                 config.transaction_timeout,
                 id,
                 dry_run,
+                // The node holds the key, so we cannot sign a gas-estimation tx locally.
+                None,
             )
             .await
         } else {
             // Deploy with signer
             let signer = self.eth.wallet.signer().await?;
             let deployer = signer.address();
+            let wallet = EthereumWallet::new(signer);
             let provider = ProviderBuilder::<_, _, AnyNetwork>::default()
-                .wallet(EthereumWallet::new(signer))
+                .wallet(wallet.clone())
                 .connect_provider(provider);
+            // On seismic chains, gas estimation must go through raw signed bytes
+            // (the node sanitizes `from` on unsigned eth_estimateGas), so deploy()
+            // needs the wallet before send time.
+            let estimation_wallet = config.seismic.then_some(wallet);
             self.deploy(
                 abi,
                 bin,
@@ -201,6 +209,7 @@ impl CreateArgs {
                 config.transaction_timeout,
                 id,
                 dry_run,
+                estimation_wallet,
             )
             .await
         }
@@ -279,6 +288,7 @@ impl CreateArgs {
         timeout: u64,
         id: ArtifactId,
         dry_run: bool,
+        estimation_wallet: Option<EthereumWallet>,
     ) -> Result<()> {
         let bin = bin.into_bytes().unwrap_or_default();
         if bin.is_empty() {
@@ -316,12 +326,8 @@ impl CreateArgs {
             deployer.tx.set_value(value);
         }
 
-        deployer.tx.set_gas_limit(if let Some(gas_limit) = self.tx.gas_limit {
-            Ok(gas_limit.to())
-        } else {
-            provider.estimate_gas(deployer.tx.clone()).await
-        }?);
-
+        // Fees are set before the gas limit: the signed gas estimate below signs the
+        // tx, which requires a fully formed request.
         if is_legacy {
             let gas_price = if let Some(gas_price) = self.tx.gas_price {
                 gas_price.to()
@@ -345,6 +351,29 @@ impl CreateArgs {
             deployer.tx.set_max_fee_per_gas(max_fee);
             deployer.tx.set_max_priority_fee_per_gas(priority_fee);
         }
+
+        deployer.tx.set_gas_limit(if let Some(gas_limit) = self.tx.gas_limit {
+            gas_limit.to()
+        } else if let Some(wallet) = &estimation_wallet {
+            // The node clears `from` on unsigned eth_estimateGas (privacy
+            // sanitization), underpricing any tx whose gas depends on msg.sender
+            // (e.g. Ownable constructors storing the deployer) — sent with such an
+            // estimate, the deploy runs out of gas. Estimate via raw signed bytes
+            // instead: the signature authenticates the real sender.
+            match signed_gas_estimate(&*provider, &deployer.tx, wallet).await {
+                Ok(gas) => gas,
+                Err(err) => {
+                    sh_warn!(
+                        "Signed gas estimation failed ({err}); falling back to unsigned \
+                         estimation, which may underestimate msg.sender-dependent gas. \
+                         Use --gas-limit for precise control."
+                    )?;
+                    provider.estimate_gas(deployer.tx.clone()).await?
+                }
+            }
+        } else {
+            provider.estimate_gas(deployer.tx.clone()).await?
+        });
 
         // Before we actually deploy the contract we try check if the verify settings are valid
         let mut constructor_args = None;
@@ -511,6 +540,26 @@ impl<P, C> From<Deployer<P>> for ContractDeploymentTx<P, C> {
     fn from(deployer: Deployer<P>) -> Self {
         Self { deployer, _contract: PhantomData }
     }
+}
+
+/// Estimate gas by signing the tx and submitting the raw bytes to
+/// `eth_estimateGas`, so the node estimates with the real sender instead of the
+/// sanitized zero address. The tx is signed with the block gas limit as a
+/// placeholder (a signed tx requires a gas limit); it is never broadcast.
+async fn signed_gas_estimate<P: Provider<AnyNetwork>>(
+    provider: &P,
+    tx: &WithOtherFields<TransactionRequest>,
+    wallet: &EthereumWallet,
+) -> Result<u64> {
+    let block = provider
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("failed to fetch latest block"))?;
+
+    let mut estimate_tx = tx.clone();
+    estimate_tx.set_gas_limit(block.header.gas_limit);
+
+    foundry_common::seismic::request_signed_gas_estimate(provider, &estimate_tx, wallet).await
 }
 
 /// Helper which manages the deployment transaction of a smart contract

--- a/crates/forge/tests/cli/create.rs
+++ b/crates/forge/tests/cli/create.rs
@@ -494,3 +494,54 @@ Error: no bytecode found in bin object for AbstractCounter
 
 "#]]);
 });
+
+// Deploying a contract whose constructor stores msg.sender must succeed without
+// an explicit --gas-limit. Unsigned eth_estimateGas is sanitized node-side
+// (`from` cleared), so the owner SSTORE is priced as a zero-store and the
+// estimate lands ~20k gas short — a deploy sent with it runs out of gas.
+// forge create estimates via raw signed bytes instead, which keep the real
+// sender (see foundry_common::seismic::request_signed_gas_estimate).
+forgetest_async!(test_seismic_create_signed_gas_estimate, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let deployer = wallet.address();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    prj.add_source(
+        "Owned",
+        r#"
+pragma solidity >=0.8.0;
+
+contract Owned {
+    address public owner;
+    constructor() {
+        owner = msg.sender;
+    }
+}
+"#,
+    );
+
+    cmd.forge_fuse()
+        .args([
+            "create",
+            "./src/Owned.sol:Owned",
+            "--rpc-url",
+            rpc.as_str(),
+            "--private-key",
+            pk.as_str(),
+            "--broadcast",
+        ])
+        .assert_success();
+
+    // "Deployed to:" prints even when the deploy reverts out of gas, so assert
+    // the constructor actually ran: code at the address and the owner in slot 0.
+    let address = Address::from_str("0x5FbDB2315678afecb367f032d93F642f64180aa3").unwrap();
+    let code = api.get_code(address, None).await.unwrap();
+    assert!(!code.is_empty(), "no code at deploy address — deploy reverted (out of gas?)");
+
+    let owner = api.storage_at(address, alloy_primitives::U256::ZERO, None).await.unwrap();
+    assert_eq!(Address::from_word(owner), deployer, "owner slot not set to deployer");
+});


### PR DESCRIPTION
The node sanitizes unsigned `eth_estimateGas`, so estimation runs with the zero address as sender. Any deploy whose gas depends on `msg.sender` is priced as a zero-store, underestimating the gas price. `forge create` uses the exact estimate as the gas limit, so such deploys deterministically run out of gas, burn the full gas limit, and still print "Deployed to: …".


Changes:
- Estimate the gas with a signed read instead. The signature authenticates the real sender, so the node estimates the tx that will actually be sent
- `request_signed_gas_estimate` lifted from cast's `seismic_utils` into `foundry_common::seismic`
- `forge create` threads the wallet into `deploy()`, gated on `config.seismic`
- Fee filling moved before gas estimation (signing needs a fully formed tx)
- On signed-estimate failure: warn and fall back to the unsigned estimate
- `--unlocked` keeps the unsigned path (the node holds the key)
- `--gas-limit` still bypasses estimation entirely