### PR TITLE
feat(anvil): surface Seismic tx type for signed-read calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,7 +3696,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3961,7 +3961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6167,7 +6167,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6221,7 +6221,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7065,7 +7065,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7310,7 +7310,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "revm",
@@ -8185,7 +8185,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8475,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8493,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -8504,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -8520,7 +8520,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8535,7 +8535,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -8548,7 +8548,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "either",
@@ -8560,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -8578,7 +8578,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "either",
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -8891,7 +8891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -9899,7 +9899,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.0",
 ]
@@ -10240,7 +10240,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -10347,7 +10347,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10367,7 +10367,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11669,7 +11669,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,12 +394,12 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # seismic-revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "025bdf5924af5aa966c5b349f1f11a6d3e547fa4" }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1375,9 +1375,7 @@ impl EthApi {
                 }
             }
             other => {
-                // `seismic_call` re-derives the classification via
-                // validate_seismic_call_tx_metadata on this authenticated request,
-                // so the marker isn't needed here.
+                // seismic_call re-derives the classification, so the marker is unused here.
                 let (request, _) = Self::recover_signed_request(other)?;
                 self.seismic_call(request, block_number, overrides).await
             }
@@ -1485,9 +1483,6 @@ impl EthApi {
     ) -> Result<U256> {
         node_info!("eth_estimateGas");
 
-        // An unsigned request is unauthenticated, so its estimate must run as a standard tx; only a
-        // signed (authenticated) seismic request estimates as Seismic, matching what will actually
-        // be sent. Otherwise an `isSeismicTx()`-gated function reverts during estimation.
         let (request, classification) = match request {
             SeismicCallRequest::TransactionRequest(mut tx) => {
                 // See comment in eth_call above — same rationale.
@@ -3207,10 +3202,8 @@ impl EthApi {
             }
         };
 
-        // Recover the sender — seismic txs use seismic-specific recovery,
-        // non-seismic txs use PendingTransaction for standard recovery. The signature is what
-        // authenticates the request, so only a signed *seismic* tx may be classified as Seismic;
-        // a signed standard tx recovers a real sender but is not a Seismic call.
+        // Recover the sender — seismic txs use seismic-specific recovery, non-seismic use
+        // PendingTransaction for standard recovery.
         let (tx, sender, classification) =
             if let Some(signed_seismic_tx) = typed_tx.clone().seismic() {
                 let sender = signed_seismic_tx.recover_signer().map_err(|e| {
@@ -3251,6 +3244,14 @@ impl EthApi {
             if overrides.has_state() || overrides.has_block() {
                 return Err(BlockchainError::EvmOverrideError(
                     "not available on past forked blocks".to_string(),
+                ));
+            }
+            // The fork RPC gets only the recovered request, so it can't reproduce txtype 74 — fail
+            // explicitly rather than silently estimating a signed read as standard.
+            if matches!(classification, SeismicClassification::TrustedSeismic) {
+                return Err(BlockchainError::Message(
+                    "signed Seismic gas estimation is not supported for blocks predating the fork"
+                        .to_string(),
                 ));
             }
             return Ok(fork.estimate_gas(&request, Some(number.into())).await?);

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1,5 +1,5 @@
 use super::{
-    backend::mem::{BlockRequest, DatabaseRef, State},
+    backend::mem::{BlockRequest, DatabaseRef, SeismicClassification, State},
     sign::build_typed_transaction,
 };
 use crate::{
@@ -1073,8 +1073,14 @@ impl EthApi {
 
         if request.inner.inner.gas.is_none() {
             // estimate if not provided
-            if let Ok(gas) =
-                self.do_estimate_gas(request.clone(), None, EvmOverrides::default()).await
+            if let Ok(gas) = self
+                .do_estimate_gas(
+                    request.clone(),
+                    None,
+                    EvmOverrides::default(),
+                    SeismicClassification::Untrusted,
+                )
+                .await
             {
                 request.inner.inner.gas = Some(gas as u64);
             }
@@ -1102,8 +1108,14 @@ impl EthApi {
 
         if request.gas.is_none() {
             // estimate if not provided
-            if let Ok(gas) =
-                self.do_estimate_gas(request.clone(), None, EvmOverrides::default()).await
+            if let Ok(gas) = self
+                .do_estimate_gas(
+                    request.clone(),
+                    None,
+                    EvmOverrides::default(),
+                    SeismicClassification::Untrusted,
+                )
+                .await
             {
                 request.gas = Some(gas as u64);
             }
@@ -1363,7 +1375,10 @@ impl EthApi {
                 }
             }
             other => {
-                let request = Self::recover_signed_request(other)?;
+                // `seismic_call` re-derives the classification via
+                // validate_seismic_call_tx_metadata on this authenticated request,
+                // so the marker isn't needed here.
+                let (request, _) = Self::recover_signed_request(other)?;
                 self.seismic_call(request, block_number, overrides).await
             }
         }
@@ -1441,7 +1456,7 @@ impl EthApi {
                     request.clone(),
                     FeeDetails::zero(),
                     block_env,
-                    false,
+                    SeismicClassification::Untrusted,
                 )?;
                 ensure_return_ok(exit, &out)?;
 
@@ -1470,7 +1485,10 @@ impl EthApi {
     ) -> Result<U256> {
         node_info!("eth_estimateGas");
 
-        let request = match request {
+        // An unsigned request is unauthenticated, so its estimate must run as a standard tx; only a
+        // signed (authenticated) seismic request estimates as Seismic, matching what will actually
+        // be sent. Otherwise an `isSeismicTx()`-gated function reverts during estimation.
+        let (request, classification) = match request {
             SeismicCallRequest::TransactionRequest(mut tx) => {
                 // See comment in eth_call above — same rationale.
                 tx.inner.from = None;
@@ -1480,7 +1498,7 @@ impl EthApi {
                 tx.inner.max_fee_per_gas = None;
                 tx.inner.max_priority_fee_per_gas = None;
                 tx.inner.max_fee_per_blob_gas = None;
-                WithOtherFields::new(tx)
+                (WithOtherFields::new(tx), SeismicClassification::Untrusted)
             }
             other => Self::recover_signed_request(other)?,
         };
@@ -1489,6 +1507,7 @@ impl EthApi {
             request,
             block_number.or_else(|| Some(BlockNumber::Pending.into())),
             overrides,
+            classification,
         )
         .await
         .map(U256::from)
@@ -2578,7 +2597,12 @@ impl EthApi {
                         // Estimate gas
                         if tx_req.gas.is_none()
                             && let Ok(gas) = self
-                                .do_estimate_gas(tx_req.clone(), None, EvmOverrides::default())
+                                .do_estimate_gas(
+                                    tx_req.clone(),
+                                    None,
+                                    EvmOverrides::default(),
+                                    SeismicClassification::Untrusted,
+                                )
                                 .await
                         {
                             tx_req.gas = Some(gas as u64);
@@ -3055,6 +3079,7 @@ impl EthApi {
             seismic_request.clone(),
             Some(BlockId::latest()),
             EvmOverrides::default(),
+            SeismicClassification::Untrusted,
         );
 
         let fees_fut = self.fee_history(
@@ -3158,7 +3183,7 @@ impl EthApi {
     /// WithOtherFields<TransactionRequest> with the authenticated sender set as `from`.
     fn recover_signed_request(
         request: SeismicCallRequest,
-    ) -> Result<WithOtherFields<TransactionRequest>> {
+    ) -> Result<(WithOtherFields<TransactionRequest>, SeismicClassification)> {
         let typed_tx = match request {
             SeismicCallRequest::TypedData(td) => {
                 TypedTransaction::decode_712(&td).map_err(|e| {
@@ -3183,28 +3208,31 @@ impl EthApi {
         };
 
         // Recover the sender — seismic txs use seismic-specific recovery,
-        // non-seismic txs use PendingTransaction for standard recovery.
-        let (tx, sender) = if let Some(signed_seismic_tx) = typed_tx.clone().seismic() {
-            let sender = signed_seismic_tx.recover_signer().map_err(|e| {
-                BlockchainError::Message(format!("Failed to recover signer: {e:?}"))
-            })?;
-            let tx: TransactionRequest = signed_seismic_tx.tx().clone().into();
-            (tx, sender)
-        } else {
-            let tx = TransactionRequest::try_from(typed_tx.clone()).map_err(|_| {
-                BlockchainError::Message(
-                    "Failed to convert typed transaction to request".to_string(),
-                )
-            })?;
-            let pending = PendingTransaction::new(typed_tx).map_err(|e| {
-                BlockchainError::Message(format!("Failed to recover signer: {e:?}"))
-            })?;
-            (tx, *pending.sender())
-        };
+        // non-seismic txs use PendingTransaction for standard recovery. The signature is what
+        // authenticates the request, so only a signed *seismic* tx may be classified as Seismic;
+        // a signed standard tx recovers a real sender but is not a Seismic call.
+        let (tx, sender, classification) =
+            if let Some(signed_seismic_tx) = typed_tx.clone().seismic() {
+                let sender = signed_seismic_tx.recover_signer().map_err(|e| {
+                    BlockchainError::Message(format!("Failed to recover signer: {e:?}"))
+                })?;
+                let tx: TransactionRequest = signed_seismic_tx.tx().clone().into();
+                (tx, sender, SeismicClassification::TrustedSeismic)
+            } else {
+                let tx = TransactionRequest::try_from(typed_tx.clone()).map_err(|_| {
+                    BlockchainError::Message(
+                        "Failed to convert typed transaction to request".to_string(),
+                    )
+                })?;
+                let pending = PendingTransaction::new(typed_tx).map_err(|e| {
+                    BlockchainError::Message(format!("Failed to recover signer: {e:?}"))
+                })?;
+                (tx, *pending.sender(), SeismicClassification::Untrusted)
+            };
 
         let mut request = WithOtherFields::new(tx);
         request.inner.inner.from = Some(sender);
-        Ok(request)
+        Ok((request, classification))
     }
 
     async fn do_estimate_gas(
@@ -3212,6 +3240,7 @@ impl EthApi {
         request: WithOtherFields<TransactionRequest>,
         block_number: Option<BlockId>,
         overrides: EvmOverrides,
+        classification: SeismicClassification,
     ) -> Result<u128> {
         let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
@@ -3242,7 +3271,7 @@ impl EthApi {
                     if let Some(block_overrides) = overrides.block {
                         cache_db.apply_block_overrides(*block_overrides, &mut block);
                     }
-                    this.do_estimate_gas_with_state(request, &cache_db, block)
+                    this.do_estimate_gas_with_state(request, &cache_db, block, classification)
                 })
                 .await?
         })
@@ -3257,6 +3286,7 @@ impl EthApi {
         mut seismic_request: WithOtherFields<TransactionRequest>,
         state: &dyn DatabaseRef,
         block_env: BlockEnv,
+        classification: SeismicClassification,
     ) -> Result<u128> {
         // If the request is a simple native token transfer we can optimize
         // We assume it's a transfer if we have no input data.
@@ -3317,7 +3347,7 @@ impl EthApi {
             call_to_estimate,
             fees.clone(),
             block_env.clone(),
-            false,
+            classification,
         );
 
         let gas_used = match ethres.try_into()? {
@@ -3355,7 +3385,7 @@ impl EthApi {
                 WithOtherFields::new(request.clone()),
                 fees.clone(),
                 block_env.clone(),
-                false,
+                classification,
             );
 
             match ethres.try_into()? {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1441,6 +1441,7 @@ impl EthApi {
                     request.clone(),
                     FeeDetails::zero(),
                     block_env,
+                    false,
                 )?;
                 ensure_return_ok(exit, &out)?;
 
@@ -3311,8 +3312,13 @@ impl EthApi {
         call_to_estimate.gas = Some(highest_gas_limit as u64);
 
         // execute the call without writing to db
-        let ethres =
-            self.backend.call_with_state(&state, call_to_estimate, fees.clone(), block_env.clone());
+        let ethres = self.backend.call_with_state(
+            &state,
+            call_to_estimate,
+            fees.clone(),
+            block_env.clone(),
+            false,
+        );
 
         let gas_used = match ethres.try_into()? {
             GasEstimationCallResult::Success(gas) => Ok(gas),
@@ -3349,6 +3355,7 @@ impl EthApi {
                 WithOtherFields::new(request.clone()),
                 fees.clone(),
                 block_env.clone(),
+                false,
             );
 
             match ethres.try_into()? {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1705,7 +1705,12 @@ impl Backend {
         fee_details: FeeDetails,
         block_env: BlockEnv,
     ) -> Env {
-        let tx_type = request.minimal_tx_type() as u8;
+        // Signed reads (eth_call carrying seismic_elements) execute as the Seismic tx type.
+        let tx_type = if request.inner.seismic_elements.is_some() {
+            SEISMIC_TX_TYPE_ID
+        } else {
+            request.minimal_tx_type() as u8
+        };
         let cloned_inner = request.inner.clone();
 
         let WithOtherFields::<TransactionRequest> {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -264,12 +264,9 @@ pub struct Backend {
     disable_pool_balance_checks: bool,
 }
 
-/// Whether a call/estimate may be classified as a Seismic transaction (`txtype() == 74`).
-///
-/// Only an authenticated signed-read path may pass `TrustedSeismic`; every other caller must pass
-/// `Untrusted`, so `txtype()` is derived from standard EIP-2718 fields and cannot be forged by an
-/// unauthenticated request. This is a typed marker rather than a bare `bool` so each caller must
-/// state its trust level explicitly.
+/// Whether a call may be classified as Seismic (`txtype() == 74`). Only an authenticated
+/// signed-read path passes `TrustedSeismic`; all others pass `Untrusted` so `txtype()` can't be
+/// forged from user-supplied fields.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SeismicClassification {
     /// Authenticated signed Seismic read/tx — classify as Seismic (`0x4A`).
@@ -1726,9 +1723,6 @@ impl Backend {
         block_env: BlockEnv,
         classification: SeismicClassification,
     ) -> Env {
-        // Only the authenticated signed-read path may classify a call as Seismic. Never infer it
-        // from user-supplied fields, or an unauthenticated eth_call/simulateV1/trace could forge
-        // txtype() == 74.
         let tx_type = match classification {
             SeismicClassification::TrustedSeismic => SEISMIC_TX_TYPE_ID,
             SeismicClassification::Untrusted => request.minimal_tx_type() as u8,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -264,6 +264,20 @@ pub struct Backend {
     disable_pool_balance_checks: bool,
 }
 
+/// Whether a call/estimate may be classified as a Seismic transaction (`txtype() == 74`).
+///
+/// Only an authenticated signed-read path may pass `TrustedSeismic`; every other caller must pass
+/// `Untrusted`, so `txtype()` is derived from standard EIP-2718 fields and cannot be forged by an
+/// unauthenticated request. This is a typed marker rather than a bare `bool` so each caller must
+/// state its trust level explicitly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SeismicClassification {
+    /// Authenticated signed Seismic read/tx — classify as Seismic (`0x4A`).
+    TrustedSeismic,
+    /// Not an authenticated Seismic call — classify from standard fields only.
+    Untrusted,
+}
+
 impl Backend {
     /// Initialises the balance of the given accounts
     #[expect(clippy::too_many_arguments)]
@@ -1642,7 +1656,13 @@ impl Backend {
                 if let Some(block_overrides) = overrides.block {
                     cache_db.apply_block_overrides(*block_overrides, &mut block);
                 }
-                self.call_with_state(&cache_db, request, fee_details, block, false)
+                self.call_with_state(
+                    &cache_db,
+                    request,
+                    fee_details,
+                    block,
+                    SeismicClassification::Untrusted,
+                )
             }?;
             trace!(target: "backend", "call return {:?} out: {:?} gas {} on block {}", exit, out, gas, block_number);
             Ok((exit, out, gas, state))
@@ -1704,13 +1724,15 @@ impl Backend {
         request: WithOtherFields<TransactionRequest>,
         fee_details: FeeDetails,
         block_env: BlockEnv,
-        trusted_seismic: bool,
+        classification: SeismicClassification,
     ) -> Env {
-        // Only the authenticated signed-read path (after validate_seismic_call_tx_metadata) may
-        // classify a call as Seismic. Never infer it from user-supplied fields, or an
-        // unauthenticated eth_call/simulateV1/trace could forge txtype() == 74.
-        let tx_type =
-            if trusted_seismic { SEISMIC_TX_TYPE_ID } else { request.minimal_tx_type() as u8 };
+        // Only the authenticated signed-read path may classify a call as Seismic. Never infer it
+        // from user-supplied fields, or an unauthenticated eth_call/simulateV1/trace could forge
+        // txtype() == 74.
+        let tx_type = match classification {
+            SeismicClassification::TrustedSeismic => SEISMIC_TX_TYPE_ID,
+            SeismicClassification::Untrusted => request.minimal_tx_type() as u8,
+        };
         let cloned_inner = request.inner.clone();
 
         let WithOtherFields::<TransactionRequest> {
@@ -1902,7 +1924,7 @@ impl Backend {
                         WithOtherFields::new(seismic_request.clone()),
                         fee_details,
                         block_env.clone(),
-                        false,
+                        SeismicClassification::Untrusted,
                     );
 
                     // Always disable EIP-3607
@@ -2076,11 +2098,11 @@ impl Backend {
         request: WithOtherFields<TransactionRequest>,
         fee_details: FeeDetails,
         block_env: BlockEnv,
-        trusted_seismic: bool,
+        classification: SeismicClassification,
     ) -> Result<(InstructionResult, Option<Output>, u128, State), BlockchainError> {
         let mut inspector = self.build_inspector();
         Self::check_calldata_decryption(&request)?;
-        let env = self.build_call_env(request, fee_details, block_env, trusted_seismic);
+        let env = self.build_call_env(request, fee_details, block_env, classification);
         let mut evm = self.new_evm_with_inspector_ref(state, &env, &mut inspector);
         let ResultAndState { result, state } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out) = match result {
@@ -2169,8 +2191,17 @@ impl Backend {
                 return Err(BlockchainError::Message(format!("Invalid AEAD metadata: {e}")));
             }
         }
-        let (exit_reason, out, gas_used, state) =
-            self.call_with_state(state, request, fee_details, block_env, tx_metadata.is_some())?;
+        let (exit_reason, out, gas_used, state) = self.call_with_state(
+            state,
+            request,
+            fee_details,
+            block_env,
+            if tx_metadata.is_some() {
+                SeismicClassification::TrustedSeismic
+            } else {
+                SeismicClassification::Untrusted
+            },
+        )?;
         let output_data = out
             .map(|plaintext_output| match tx_metadata {
                 Some(tx_metadata) => tx_metadata
@@ -2225,7 +2256,12 @@ impl Backend {
                                 TracingInspectorConfig::from_geth_call_config(&call_config),
                             );
                             Self::check_calldata_decryption(&request)?;
-                            let env = self.build_call_env(request, fee_details, block, false);
+                            let env = self.build_call_env(
+                                request,
+                                fee_details,
+                                block,
+                                SeismicClassification::Untrusted,
+                            );
                             let mut evm =
                                 self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
                             let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
@@ -2259,7 +2295,12 @@ impl Backend {
                                 .map_err(|err| BlockchainError::Message(err.to_string()))?;
 
                         Self::check_calldata_decryption(&request)?;
-                        let env = self.build_call_env(request, fee_details, block.clone(), false);
+                        let env = self.build_call_env(
+                            request,
+                            fee_details,
+                            block.clone(),
+                            SeismicClassification::Untrusted,
+                        );
                         let mut evm =
                             self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
                         let result = evm.transact(env.tx.clone())?;
@@ -2284,7 +2325,8 @@ impl Backend {
                 .with_tracing_config(TracingInspectorConfig::from_geth_config(&config));
 
             Self::check_calldata_decryption(&request)?;
-            let env = self.build_call_env(request, fee_details, block, false);
+            let env =
+                self.build_call_env(request, fee_details, block, SeismicClassification::Untrusted);
             let mut evm = self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
             let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
 
@@ -2327,7 +2369,8 @@ impl Backend {
             AccessListInspector::new(request.inner.inner.access_list.clone().unwrap_or_default());
 
         Self::check_calldata_decryption(&request)?;
-        let env = self.build_call_env(request, fee_details, block_env, false);
+        let env =
+            self.build_call_env(request, fee_details, block_env, SeismicClassification::Untrusted);
         let mut evm = self.new_evm_with_inspector_ref(state, &env, &mut inspector);
         let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out) = match result {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1642,7 +1642,7 @@ impl Backend {
                 if let Some(block_overrides) = overrides.block {
                     cache_db.apply_block_overrides(*block_overrides, &mut block);
                 }
-                self.call_with_state(&cache_db, request, fee_details, block)
+                self.call_with_state(&cache_db, request, fee_details, block, false)
             }?;
             trace!(target: "backend", "call return {:?} out: {:?} gas {} on block {}", exit, out, gas, block_number);
             Ok((exit, out, gas, state))
@@ -1704,13 +1704,13 @@ impl Backend {
         request: WithOtherFields<TransactionRequest>,
         fee_details: FeeDetails,
         block_env: BlockEnv,
+        trusted_seismic: bool,
     ) -> Env {
-        // Signed reads (eth_call carrying seismic_elements) execute as the Seismic tx type.
-        let tx_type = if request.inner.seismic_elements.is_some() {
-            SEISMIC_TX_TYPE_ID
-        } else {
-            request.minimal_tx_type() as u8
-        };
+        // Only the authenticated signed-read path (after validate_seismic_call_tx_metadata) may
+        // classify a call as Seismic. Never infer it from user-supplied fields, or an
+        // unauthenticated eth_call/simulateV1/trace could forge txtype() == 74.
+        let tx_type =
+            if trusted_seismic { SEISMIC_TX_TYPE_ID } else { request.minimal_tx_type() as u8 };
         let cloned_inner = request.inner.clone();
 
         let WithOtherFields::<TransactionRequest> {
@@ -1902,6 +1902,7 @@ impl Backend {
                         WithOtherFields::new(seismic_request.clone()),
                         fee_details,
                         block_env.clone(),
+                        false,
                     );
 
                     // Always disable EIP-3607
@@ -2075,10 +2076,11 @@ impl Backend {
         request: WithOtherFields<TransactionRequest>,
         fee_details: FeeDetails,
         block_env: BlockEnv,
+        trusted_seismic: bool,
     ) -> Result<(InstructionResult, Option<Output>, u128, State), BlockchainError> {
         let mut inspector = self.build_inspector();
         Self::check_calldata_decryption(&request)?;
-        let env = self.build_call_env(request, fee_details, block_env);
+        let env = self.build_call_env(request, fee_details, block_env, trusted_seismic);
         let mut evm = self.new_evm_with_inspector_ref(state, &env, &mut inspector);
         let ResultAndState { result, state } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out) = match result {
@@ -2168,7 +2170,7 @@ impl Backend {
             }
         }
         let (exit_reason, out, gas_used, state) =
-            self.call_with_state(state, request, fee_details, block_env)?;
+            self.call_with_state(state, request, fee_details, block_env, tx_metadata.is_some())?;
         let output_data = out
             .map(|plaintext_output| match tx_metadata {
                 Some(tx_metadata) => tx_metadata
@@ -2223,7 +2225,7 @@ impl Backend {
                                 TracingInspectorConfig::from_geth_call_config(&call_config),
                             );
                             Self::check_calldata_decryption(&request)?;
-                            let env = self.build_call_env(request, fee_details, block);
+                            let env = self.build_call_env(request, fee_details, block, false);
                             let mut evm =
                                 self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
                             let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
@@ -2257,7 +2259,7 @@ impl Backend {
                                 .map_err(|err| BlockchainError::Message(err.to_string()))?;
 
                         Self::check_calldata_decryption(&request)?;
-                        let env = self.build_call_env(request, fee_details, block.clone());
+                        let env = self.build_call_env(request, fee_details, block.clone(), false);
                         let mut evm =
                             self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
                         let result = evm.transact(env.tx.clone())?;
@@ -2282,7 +2284,7 @@ impl Backend {
                 .with_tracing_config(TracingInspectorConfig::from_geth_config(&config));
 
             Self::check_calldata_decryption(&request)?;
-            let env = self.build_call_env(request, fee_details, block);
+            let env = self.build_call_env(request, fee_details, block, false);
             let mut evm = self.new_evm_with_inspector_ref(&cache_db, &env, &mut inspector);
             let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
 
@@ -2325,7 +2327,7 @@ impl Backend {
             AccessListInspector::new(request.inner.inner.access_list.clone().unwrap_or_default());
 
         Self::check_calldata_decryption(&request)?;
-        let env = self.build_call_env(request, fee_details, block_env);
+        let env = self.build_call_env(request, fee_details, block_env, false);
         let mut evm = self.new_evm_with_inspector_ref(state, &env, &mut inspector);
         let ResultAndState { result, state: _ } = evm.transact(env.tx)?;
         let (exit_reason, gas_used, out) = match result {

--- a/crates/anvil/tests/it/seismic.rs
+++ b/crates/anvil/tests/it/seismic.rs
@@ -21,9 +21,9 @@ use std::{fs, str::FromStr};
 
 use seismic_prelude::foundry::{
     AnyNetwork, AnyTxEnvelope, EthereumWallet, SeismicCallExt, SeismicCallRequest,
-    SeismicProviderBuilder, SeismicProviderExt, ShieldedCallExt, SignedProviderExt,
-    TransactionRequest, TxLegacyFields, TxSeismic, TxSeismicElements, TxSeismicMetadata,
-    TypedDataRequest, test_utils, tx_builder,
+    SeismicProviderBuilder, SeismicProviderExt, ShieldedCallExt, SignedProviderExt, SimBlock,
+    SimulatePayload, TransactionRequest, TxLegacyFields, TxSeismic, TxSeismicElements,
+    TxSeismicMetadata, TypedDataRequest, test_utils, tx_builder,
 };
 
 // common utils
@@ -830,4 +830,77 @@ async fn test_seismic_fork_send_tx() {
 
     let balance = provider.get_balance(to).await.unwrap();
     assert_eq!(balance, U256::from(1e18 as u64));
+}
+
+// Deploy bytecode for a probe exposing isSeismic() (returns txtype() == 0x4A).
+const TXTYPE_PROBE_DEPLOY: &str = "6080604052348015600e575f5ffd5b5060d580601a5f395ff3fe6080604052348015600e575f5ffd5b5060043610603a575f3560e01c806302ce808814603e578063266cf1091460545780639f9a32b014605d575b5f5ffd5b604051604ab21481526020015b60405180910390f35b605bb25f55565b005b60636070565b604051908152602001604b565b5f548156fea26469706673582212200b97d0c18f63a3181d9a4506b939f164fbf13afe1d1ba0d19c89e782713cd1c764736f6c63782c302e382e33312d646576656c6f702e323032362e372e32302b636f6d6d69742e66643566333839632e6d6f64005d";
+
+/// An unauthenticated eth_simulateV1 call carrying valid seismic ciphertext + elements but no
+/// signature must NOT be classified as a Seismic tx. Otherwise txtype()/isSeismicTx() would
+/// report an encrypted channel for a forged, unauthenticated read.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txtype_unauthenticated_simulate_cannot_forge_seismic() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(true).await.unwrap();
+    let signer = handle.dev_wallets().next().unwrap();
+    let provider = SeismicProviderBuilder::new()
+        .foundry()
+        .wallet(EthereumWallet::new(signer.clone()))
+        .connect_http(reqwest::Url::parse(handle.http_endpoint().as_str()).unwrap())
+        .await
+        .unwrap();
+    let deployer = handle.dev_accounts().next().unwrap();
+    let network_pubkey = provider.get_tee_pubkey().await.unwrap();
+    let chain_id = provider.get_chain_id().await.unwrap();
+
+    // Deploy the probe.
+    let deploy_code = Bytes::from_hex(TXTYPE_PROBE_DEPLOY).unwrap();
+    let deploy_req =
+        tx_builder().with_from(deployer).with_kind(TxKind::Create).with_input(deploy_code).into();
+    let contract = provider
+        .send_transaction(deploy_req.into())
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap()
+        .contract_address
+        .unwrap();
+
+    // isSeismic() selector, encrypted into a valid-but-UNSIGNED seismic request (attacker uses the
+    // public TEE key + arbitrary metadata; decryptable != authenticated).
+    let is_seismic = Bytes::from_hex("02ce8088").unwrap();
+    let forged = get_unsigned_seismic_tx_request(
+        &signer,
+        &network_pubkey,
+        provider.get_transaction_count(deployer).await.unwrap(),
+        TxKind::Call(contract),
+        chain_id,
+        is_seismic,
+        true,
+    )
+    .await;
+
+    let payload = SimulatePayload {
+        block_state_calls: vec![SimBlock {
+            block_overrides: None,
+            state_overrides: None,
+            calls: vec![forged.into()],
+        }],
+        trace_transfers: false,
+        validation: false,
+        return_full_transactions: false,
+    };
+    let blocks = api.simulate_v1(payload, None).await.unwrap();
+    let call = &blocks[0].calls[0];
+
+    // The call must actually execute (so we're testing isSeismic()'s result, not a silent
+    // failure that would also decode to zero) and return the 32-byte bool `false`.
+    assert!(call.status, "forged simulate call did not execute: {:?}", call.error);
+    assert_eq!(call.return_data.len(), 32, "expected a 32-byte bool return");
+    assert_eq!(
+        U256::from_be_slice(call.return_data.as_ref()),
+        U256::ZERO,
+        "unauthenticated eth_simulateV1 forged txtype() == 74 (confidentiality bypass)"
+    );
 }

--- a/crates/anvil/tests/it/seismic.rs
+++ b/crates/anvil/tests/it/seismic.rs
@@ -904,3 +904,83 @@ async fn test_txtype_unauthenticated_simulate_cannot_forge_seismic() {
         "unauthenticated eth_simulateV1 forged txtype() == 74 (confidentiality bypass)"
     );
 }
+
+/// A signed (authenticated) eth_estimateGas must execute as a Seismic tx (`txtype() == 74`), so an
+/// `isSeismicTx()`-dependent path is estimated for what will actually be sent. The probe's
+/// `record()` stores `txtype()` into slot 0, so a signed estimate pays the 0 -> nonzero SSTORE
+/// (`txtype()` == 74) while an unsigned estimate stores 0 -> 0; the signed estimate is therefore
+/// materially higher. Regression test for the P2 estimator defect (it previously ran every
+/// estimate as a non-Seismic tx, so `scast send --seismic` / `forge create` could revert during
+/// automatic estimation).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txtype_signed_estimate_executes_as_seismic() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(true).await.unwrap();
+    let signer = handle.dev_wallets().next().unwrap();
+    let provider = SeismicProviderBuilder::new()
+        .foundry()
+        .wallet(EthereumWallet::new(signer.clone()))
+        .connect_http(reqwest::Url::parse(handle.http_endpoint().as_str()).unwrap())
+        .await
+        .unwrap();
+    let deployer = handle.dev_accounts().next().unwrap();
+    let network_pubkey = provider.get_tee_pubkey().await.unwrap();
+    let chain_id = provider.get_chain_id().await.unwrap();
+
+    // Deploy the probe.
+    let deploy_code = Bytes::from_hex(TXTYPE_PROBE_DEPLOY).unwrap();
+    let deploy_req =
+        tx_builder().with_from(deployer).with_kind(TxKind::Create).with_input(deploy_code).into();
+    let contract = provider
+        .send_transaction(deploy_req.into())
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap()
+        .contract_address
+        .unwrap();
+
+    // record() — stores txtype() into slot 0.
+    let record = Bytes::from_hex("266cf109").unwrap();
+    let nonce = provider.get_transaction_count(deployer).await.unwrap();
+
+    // Signed seismic read: the estimator must run it as txtype 74 (SSTORE 0 -> 74).
+    let signed = get_signed_seismic_tx_typed_data(
+        &signer,
+        &network_pubkey,
+        nonce,
+        TxKind::Call(contract),
+        chain_id,
+        record.clone(),
+        true,
+    )
+    .await;
+    let signed_gas = api
+        .estimate_gas(SeismicCallRequest::TypedData(signed), None, EvmOverrides::default())
+        .await
+        .unwrap();
+
+    // Unsigned request to the same function: the estimator runs it as a standard tx (txtype 0),
+    // so record() does SSTORE 0 -> 0.
+    let unsigned = TransactionRequest {
+        inner: AlloyTransactionRequest {
+            to: Some(TxKind::Call(contract)),
+            input: TransactionInput { input: Some(record), data: None },
+            ..Default::default()
+        },
+        seismic_elements: None,
+    };
+    let unsigned_gas = api
+        .estimate_gas(WithOtherFields::new(unsigned).into(), None, EvmOverrides::default())
+        .await
+        .unwrap();
+
+    // The 0 -> nonzero SSTORE costs ~20k more gas. If the signed estimate had run as a standard tx
+    // (the P2 bug), txtype() would be 0 and the two estimates would match.
+    assert!(
+        signed_gas > unsigned_gas + U256::from(15_000),
+        "signed estimate ({signed_gas}) should exceed unsigned ({unsigned_gas}) by the txtype-74 SSTORE cost; \
+         if they match, the signed estimate ran as a non-Seismic tx"
+    );
+}

--- a/crates/anvil/tests/it/seismic.rs
+++ b/crates/anvil/tests/it/seismic.rs
@@ -835,6 +835,10 @@ async fn test_seismic_fork_send_tx() {
 // Deploy bytecode for a probe exposing isSeismic() (returns txtype() == 0x4A).
 const TXTYPE_PROBE_DEPLOY: &str = "6080604052348015600e575f5ffd5b5060d580601a5f395ff3fe6080604052348015600e575f5ffd5b5060043610603a575f3560e01c806302ce808814603e578063266cf1091460545780639f9a32b014605d575b5f5ffd5b604051604ab21481526020015b60405180910390f35b605bb25f55565b005b60636070565b604051908152602001604b565b5f548156fea26469706673582212200b97d0c18f63a3181d9a4506b939f164fbf13afe1d1ba0d19c89e782713cd1c764736f6c63782c302e382e33312d646576656c6f702e323032362e372e32302b636f6d6d69742e66643566333839632e6d6f64005d";
 
+// Deploy bytecode for a probe whose requireSeismic() [c6d819f6] reverts unless txtype() == 0x4A.
+// Success vs revert is a 74-specific signal (no other tx type passes) needing no decryption.
+const TXTYPE_GATED_PROBE_DEPLOY: &str = "6080604052348015600e575f5ffd5b50609f80601a5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c8063c6d819f614602a575b5f5ffd5b60306032565b005b604ab214603d575f5ffd5b56fea26469706673582212208b35e1118a8dc0dc3236014d69bd3f0d2b56b74698c4f84649930d9e14726b3664736f6c63782c302e382e33312d646576656c6f702e323032362e372e32302b636f6d6d69742e66643566333839632e6d6f64005d";
+
 /// An unauthenticated eth_simulateV1 call carrying valid seismic ciphertext + elements but no
 /// signature must NOT be classified as a Seismic tx. Otherwise txtype()/isSeismicTx() would
 /// report an encrypted channel for a forged, unauthenticated read.
@@ -853,7 +857,6 @@ async fn test_txtype_unauthenticated_simulate_cannot_forge_seismic() {
     let network_pubkey = provider.get_tee_pubkey().await.unwrap();
     let chain_id = provider.get_chain_id().await.unwrap();
 
-    // Deploy the probe.
     let deploy_code = Bytes::from_hex(TXTYPE_PROBE_DEPLOY).unwrap();
     let deploy_req =
         tx_builder().with_from(deployer).with_kind(TxKind::Create).with_input(deploy_code).into();
@@ -867,8 +870,7 @@ async fn test_txtype_unauthenticated_simulate_cannot_forge_seismic() {
         .contract_address
         .unwrap();
 
-    // isSeismic() selector, encrypted into a valid-but-UNSIGNED seismic request (attacker uses the
-    // public TEE key + arbitrary metadata; decryptable != authenticated).
+    // isSeismic() selector in a valid-but-unsigned seismic request (decryptable != authenticated).
     let is_seismic = Bytes::from_hex("02ce8088").unwrap();
     let forged = get_unsigned_seismic_tx_request(
         &signer,
@@ -894,8 +896,7 @@ async fn test_txtype_unauthenticated_simulate_cannot_forge_seismic() {
     let blocks = api.simulate_v1(payload, None).await.unwrap();
     let call = &blocks[0].calls[0];
 
-    // The call must actually execute (so we're testing isSeismic()'s result, not a silent
-    // failure that would also decode to zero) and return the 32-byte bool `false`.
+    // Must actually execute (not a silent failure that would also decode to zero).
     assert!(call.status, "forged simulate call did not execute: {:?}", call.error);
     assert_eq!(call.return_data.len(), 32, "expected a 32-byte bool return");
     assert_eq!(
@@ -905,15 +906,10 @@ async fn test_txtype_unauthenticated_simulate_cannot_forge_seismic() {
     );
 }
 
-/// A signed (authenticated) eth_estimateGas must execute as a Seismic tx (`txtype() == 74`), so an
-/// `isSeismicTx()`-dependent path is estimated for what will actually be sent. The probe's
-/// `record()` stores `txtype()` into slot 0, so a signed estimate pays the 0 -> nonzero SSTORE
-/// (`txtype()` == 74) while an unsigned estimate stores 0 -> 0; the signed estimate is therefore
-/// materially higher. Regression test for the P2 estimator defect (it previously ran every
-/// estimate as a non-Seismic tx, so `scast send --seismic` / `forge create` could revert during
-/// automatic estimation).
+/// A signed estimate must run as a Seismic tx (`txtype() == 74`): `requireSeismic()` succeeds for
+/// the signed read and reverts for the plain call. Regression test for the P2 estimator defect.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_txtype_signed_estimate_executes_as_seismic() {
+async fn test_txtype_signed_estimate_classifies_seismic() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     api.anvil_set_auto_mine(true).await.unwrap();
     let signer = handle.dev_wallets().next().unwrap();
@@ -927,8 +923,7 @@ async fn test_txtype_signed_estimate_executes_as_seismic() {
     let network_pubkey = provider.get_tee_pubkey().await.unwrap();
     let chain_id = provider.get_chain_id().await.unwrap();
 
-    // Deploy the probe.
-    let deploy_code = Bytes::from_hex(TXTYPE_PROBE_DEPLOY).unwrap();
+    let deploy_code = Bytes::from_hex(TXTYPE_GATED_PROBE_DEPLOY).unwrap();
     let deploy_req =
         tx_builder().with_from(deployer).with_kind(TxKind::Create).with_input(deploy_code).into();
     let contract = provider
@@ -941,46 +936,39 @@ async fn test_txtype_signed_estimate_executes_as_seismic() {
         .contract_address
         .unwrap();
 
-    // record() — stores txtype() into slot 0.
-    let record = Bytes::from_hex("266cf109").unwrap();
+    let require_seismic = Bytes::from_hex("c6d819f6").unwrap();
     let nonce = provider.get_transaction_count(deployer).await.unwrap();
 
-    // Signed seismic read: the estimator must run it as txtype 74 (SSTORE 0 -> 74).
     let signed = get_signed_seismic_tx_typed_data(
         &signer,
         &network_pubkey,
         nonce,
         TxKind::Call(contract),
         chain_id,
-        record.clone(),
+        require_seismic.clone(),
         true,
     )
     .await;
-    let signed_gas = api
+    let signed_res = api
         .estimate_gas(SeismicCallRequest::TypedData(signed), None, EvmOverrides::default())
-        .await
-        .unwrap();
+        .await;
+    assert!(
+        signed_res.is_ok(),
+        "signed estimate of requireSeismic() should succeed (txtype()==74), got {signed_res:?}"
+    );
 
-    // Unsigned request to the same function: the estimator runs it as a standard tx (txtype 0),
-    // so record() does SSTORE 0 -> 0.
-    let unsigned = TransactionRequest {
+    let plain = TransactionRequest {
         inner: AlloyTransactionRequest {
             to: Some(TxKind::Call(contract)),
-            input: TransactionInput { input: Some(record), data: None },
+            input: TransactionInput { input: Some(require_seismic), data: None },
             ..Default::default()
         },
         seismic_elements: None,
     };
-    let unsigned_gas = api
-        .estimate_gas(WithOtherFields::new(unsigned).into(), None, EvmOverrides::default())
-        .await
-        .unwrap();
-
-    // The 0 -> nonzero SSTORE costs ~20k more gas. If the signed estimate had run as a standard tx
-    // (the P2 bug), txtype() would be 0 and the two estimates would match.
+    let plain_res =
+        api.estimate_gas(WithOtherFields::new(plain).into(), None, EvmOverrides::default()).await;
     assert!(
-        signed_gas > unsigned_gas + U256::from(15_000),
-        "signed estimate ({signed_gas}) should exceed unsigned ({unsigned_gas}) by the txtype-74 SSTORE cost; \
-         if they match, the signed estimate ran as a non-Seismic tx"
+        plain_res.is_err(),
+        "plain estimate of requireSeismic() should revert (txtype()!=74), but it succeeded"
     );
 }


### PR DESCRIPTION
## Summary

`build_call_env` derived the tx type for `eth_call` via `minimal_tx_type()`, which only
looks at standard fee/access-list fields and ignores the Seismic transaction type. As a
result, during a **signed read** (an `eth_call` carrying encrypted `seismic_elements`,
transaction type `0x4A`) the EVM executed with a non-Seismic `tx_type`, so the `TXTYPE`
opcode / `isSeismicTx()` helper reported a non-Seismic type.

This sets `tx_type = SEISMIC_TX_TYPE_ID` when the call carries `seismic_elements` (a signed
read). Plain, unauthenticated `eth_call`s carry no seismic elements and are unaffected
(they continue to report `0`).

## Testing (local sanvil, built against a TXTYPE-capable revm)
- signed read → `isSeismic()` == **true**
- plain `eth_call` → `isSeismic()` == **false**
- seismic write tx (`0x4A`) → `txtype()` == **74** (unchanged)
- legacy/1559 write tx → `txtype()` == **2** (unchanged)

## Context
Part of the TXTYPE feature. Pairs with the reth `eth_call` change (same fix in the node's
RPC layer) and the opcode/builtin PRs (seismic-revm #224, seismic-solidity #392). This is
"Piece 1": it makes `isSeismicTx()` true for signed reads. Distinguishing a signed read
from a write (an `ISSIGNEDREAD` opcode) is separate follow-up work. See TXTYPE_REVIEW_HANDOFF.md.
