### PR TITLE
fix: avoid bail macros in expression position

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -415,7 +415,9 @@ impl BenchmarkProject {
             "forge_fuzz_test" => self.bench_forge_fuzz_test(version, runs, verbose),
             "forge_coverage" => self.bench_forge_coverage(version, runs, verbose),
             "forge_isolate_test" => self.bench_forge_isolate_test(version, runs, verbose),
-            _ => eyre::bail!("Unknown benchmark: {}", benchmark),
+            _ => {
+                eyre::bail!("Unknown benchmark: {}", benchmark);
+            }
         }
     }
 }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1320,7 +1320,9 @@ latest block number: {latest_block}"
                 }
                 eyre::bail!("{message}");
             }
-            eyre::bail!("failed to get block for block number: {fork_block_number}")
+            {
+                eyre::bail!("failed to get block for block number: {fork_block_number}");
+            }
         };
 
         let gas_limit = self.fork_gas_limit(&block);

--- a/crates/anvil/src/hardfork.rs
+++ b/crates/anvil/src/hardfork.rs
@@ -117,7 +117,9 @@ impl FromStr for SeismicHardfork {
         let hardfork = match s.as_str() {
             "mercury" => Self::Mercury,
             "latest" => Self::Latest,
-            _ => eyre::bail!("Unknown hardfork {s}"),
+            _ => {
+                eyre::bail!("Unknown hardfork {s}");
+            }
         };
         Ok(hardfork)
     }

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -236,7 +236,9 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                     get_event(event.signature().as_str())?
                         .decode_log_parts(core::iter::once(selector), &hex::decode(data)?)?
                 } else {
-                    eyre::bail!("No matching event signature found for selector `{selector}`")
+                    {
+                        eyre::bail!("No matching event signature found for selector `{selector}`");
+                    }
                 }
             };
             print_tokens(&decoded_event.body);
@@ -253,7 +255,9 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                     let _ = sh_println!("{}", error.signature());
                     error
                 } else {
-                    eyre::bail!("No matching error signature found for selector `{selector}`")
+                    {
+                        eyre::bail!("No matching error signature found for selector `{selector}`");
+                    }
                 }
             };
             let decoded_error = error.decode_error(&hex::decode(data)?)?;
@@ -562,7 +566,9 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             });
 
             let sig = match sigs.len() {
-                0 => eyre::bail!("No signatures found"),
+                0 => {
+                    eyre::bail!("No signatures found");
+                }
                 1 => sigs.first().unwrap(),
                 _ => {
                     let i: usize = prompt!("Select a function signature by number: ")?;

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -160,7 +160,9 @@ impl StorageArgs {
         };
         let metadata = source.items.first().unwrap();
         if metadata.is_vyper() {
-            eyre::bail!("Contract at provided address is not a valid Solidity contract")
+            {
+                eyre::bail!("Contract at provided address is not a valid Solidity contract");
+            }
         }
 
         // Create a new temp project

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -476,7 +476,9 @@ impl WalletSubcommands {
 
                 let public_key = match wallet {
                     WalletSigner::Local(wallet) => wallet.public_key(),
-                    _ => eyre::bail!("Only local wallets are supported by this command"),
+                    _ => {
+                        eyre::bail!("Only local wallets are supported by this command");
+                    }
                 };
 
                 sh_println!("0x{}", hex::encode(public_key))?;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -178,7 +178,9 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
                                 .await
                                 && code.is_empty()
                             {
-                                eyre::bail!("contract {addr:?} does not have any code")
+                                {
+                                    eyre::bail!("contract {addr:?} does not have any code");
+                                }
                             }
                         } else if Some(TxKind::Create) == req.inner.inner.to {
                             eyre::bail!("tx req is a contract deployment");
@@ -367,7 +369,9 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
             && field == "transactions"
             && !full
         {
-            eyre::bail!("use --full to view transactions")
+            {
+                eyre::bail!("use --full to view transactions");
+            }
         }
 
         let block = self
@@ -796,7 +800,9 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
                     eyre::eyre!("tx not found for sender {from} and nonce {:?}", nonce.to::<u64>())
                 })?
         } else {
-            eyre::bail!("tx hash or from address is required")
+            {
+                eyre::bail!("tx hash or from address is required");
+            }
         };
 
         Ok(if raw {
@@ -850,7 +856,9 @@ impl<P: Provider<AnyNetwork>> Cast<P> {
                     // if the async flag is provided, immediately exit if no tx is found, otherwise
                     // try to poll for it
                     if cast_async {
-                        eyre::bail!("tx not found: {:?}", tx_hash)
+                        {
+                            eyre::bail!("tx not found: {:?}", tx_hash);
+                        }
                     } else {
                         PendingTransactionBuilder::new(self.provider.root().clone(), tx_hash)
                             .with_required_confirmations(confs)
@@ -1805,7 +1813,9 @@ impl SimpleCast {
         let func = get_func(sig)?;
         match encode_function_args(&func, args) {
             Ok(res) => Ok(hex::encode_prefixed(&res[4..])),
-            Err(e) => eyre::bail!("Could not ABI encode the function and arguments: {e}"),
+            Err(e) => {
+                eyre::bail!("Could not ABI encode the function and arguments: {e}");
+            }
         }
     }
 
@@ -1835,7 +1845,9 @@ impl SimpleCast {
         let func = get_func(sig.as_str())?;
         let encoded = match encode_function_args_packed(&func, args) {
             Ok(res) => hex::encode(res),
-            Err(e) => eyre::bail!("Could not ABI encode the function and arguments: {e}"),
+            Err(e) => {
+                eyre::bail!("Could not ABI encode the function and arguments: {e}");
+            }
         };
         Ok(format!("0x{encoded}"))
     }
@@ -1912,7 +1924,7 @@ impl SimpleCast {
             | DynSolType::FixedArray(..)
             | DynSolType::Tuple(..)
             | DynSolType::CustomStruct { .. } => {
-                eyre::bail!("Type `{k_ty}` is not supported as a mapping key")
+                eyre::bail!("Type `{k_ty}` is not supported as a mapping key");
             }
             DynSolType::Sbool
             | DynSolType::Saddress
@@ -2106,7 +2118,9 @@ impl SimpleCast {
         let client = explorer_client(chain, etherscan_api_key, explorer_api_url, explorer_url)?;
         let metadata = client.contract_source_code(contract_address.parse()?).await?;
         let Some(metadata) = metadata.items.first() else {
-            eyre::bail!("Empty contract source code")
+            {
+                eyre::bail!("Empty contract source code");
+            }
         };
 
         let tmp = tempfile::tempdir()?;
@@ -2212,7 +2226,9 @@ impl SimpleCast {
 
         match result {
             Some((_nonce, selector, signature)) => Ok((selector, signature)),
-            None => eyre::bail!("No selector found"),
+            None => {
+                eyre::bail!("No selector found");
+            }
         }
     }
 

--- a/crates/cast/src/rlp_converter.rs
+++ b/crates/cast/src/rlp_converter.rs
@@ -50,7 +50,7 @@ impl Item {
         match value {
             Value::Null => Ok(Self::Data(vec![])),
             Value::Bool(_) => {
-                eyre::bail!("RLP input can not contain booleans")
+                eyre::bail!("RLP input can not contain booleans");
             }
             Value::Number(n) => {
                 Ok(Self::Data(n.to_string().parse::<U256>()?.to_be_bytes_trimmed_vec()))
@@ -58,7 +58,7 @@ impl Item {
             Value::String(s) => Ok(Self::Data(hex::decode(s).wrap_err("Could not decode hex")?)),
             Value::Array(values) => values.iter().map(Self::value_to_item).collect(),
             Value::Object(_) => {
-                eyre::bail!("RLP input can not contain objects")
+                eyre::bail!("RLP input can not contain objects");
             }
         }
     }

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -99,13 +99,13 @@ pub fn validate_from_address(
     if let Some(specified_from) = specified_from
         && specified_from != signer_address
     {
-        eyre::bail!(
-                "\
-The specified sender via CLI/env vars does not match the sender configured via
-the hardware wallet's HD Path.
-Please use the `--hd-path <PATH>` parameter to specify the BIP32 Path which
-corresponds to the sender, or let foundry automatically detect it by not specifying any sender address."
-            )
+        {
+            eyre::bail!("\
+        The specified sender via CLI/env vars does not match the sender configured via
+        the hardware wallet's HD Path.
+        Please use the `--hd-path <PATH>` parameter to specify the BIP32 Path which
+        corresponds to the sender, or let foundry automatically detect it by not specifying any sender address.");
+        }
     }
     Ok(())
 }
@@ -298,7 +298,9 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InputState> {
         let tx = tx.build_unsigned()?;
         match tx {
             AnyTypedTransaction::Ethereum(t) => Ok(hex::encode_prefixed(t.encoded_for_signing())),
-            _ => eyre::bail!("Cannot generate unsigned transaction for non-Ethereum transactions"),
+            _ => {
+                eyre::bail!("Cannot generate unsigned transaction for non-Ethereum transactions");
+            }
         }
     }
 
@@ -335,9 +337,11 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InputState> {
             self.resolve_auth(sender, tx_nonce).await?;
         } else if self.auth.is_some() {
             let Some(CliAuthorizationList::Signed(signed_auth)) = self.auth.take() else {
-                eyre::bail!(
-                    "SignedAuthorization needs to be provided for generating unsigned 7702 txs"
-                )
+                {
+                    eyre::bail!(
+                        "SignedAuthorization needs to be provided for generating unsigned 7702 txs"
+                    );
+                }
             };
 
             self.tx.set_authorization_list(vec![signed_auth]);
@@ -405,10 +409,14 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InputState> {
                         && let Some(data) = &payload.data
                         && let Ok(Some(decoded_error)) = decode_execution_revert(data).await
                     {
-                        eyre::bail!("Failed to estimate gas: {}: {}", err, decoded_error)
+                        {
+                            eyre::bail!("Failed to estimate gas: {}: {}", err, decoded_error);
+                        }
                     }
                 }
-                eyre::bail!("Failed to estimate gas: {}", err)
+                {
+                    eyre::bail!("Failed to estimate gas: {}", err);
+                }
             }
         }
     }

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -225,11 +225,15 @@ impl Cheatcode for eth_getLogsCall {
         let Self { fromBlock, toBlock, target, topics } = self;
         let (Ok(from_block), Ok(to_block)) = (u64::try_from(fromBlock), u64::try_from(toBlock))
         else {
-            bail!("blocks in block range must be less than 2^64")
+            {
+                bail!("blocks in block range must be less than 2^64");
+            }
         };
 
         if topics.len() > 4 {
-            bail!("topics array must contain at most 4 elements")
+            {
+                bail!("topics array must contain at most 4 elements");
+            }
         }
 
         let url = ccx

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -507,7 +507,9 @@ fn get_artifact_code(state: &Cheatcodes, path: &str, deployed: bool) -> Result<B
                         let name = file.replace(".sol", "");
                         PathBuf::from(format!("{file}/{name}.json"))
                     }
-                    _ => bail!("invalid artifact path"),
+                    _ => {
+                        bail!("invalid artifact path");
+                    }
                 };
 
             state.config.paths.artifacts.join(path_in_artifacts)

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -423,7 +423,9 @@ pub(super) fn parse_json_array(array: &[Value], ty: &DynSolType) -> Result<DynSo
                 array.iter().map(|e| parse_json_as(e, inner)).collect::<Result<Vec<_>>>()?;
             Ok(DynSolValue::FixedArray(values))
         }
-        _ => bail!("expected {ty}, found array"),
+        _ => {
+            bail!("expected {ty}, found array");
+        }
     }
 }
 
@@ -434,7 +436,11 @@ pub(super) fn parse_json_map(map: &Map<String, Value>, ty: &DynSolType) -> Resul
 
     let mut values = Vec::with_capacity(fields.len());
     for (field, ty) in fields.iter().zip(types.iter()) {
-        let Some(value) = map.get(field) else { bail!("field {field:?} not found in JSON object") };
+        let Some(value) = map.get(field) else {
+            {
+                bail!("field {field:?} not found in JSON object");
+            }
+        };
         values.push(parse_json_as(value, ty)?);
     }
 
@@ -638,7 +644,9 @@ pub(super) fn resolve_type(type_description: &str) -> Result<DynSolType> {
         return Ok(resolver.resolve(main_type)?);
     };
 
-    bail!("type description should be a valid Solidity type or a EIP712 `encodeType` string")
+    {
+        bail!("type description should be a valid Solidity type or a EIP712 `encodeType` string");
+    }
 }
 
 /// Upserts a value into a JSON object based on a dot-separated key.

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -79,7 +79,9 @@ impl Cheatcode for bound_0Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { current, min, max } = *self;
         let Some(mutated) = U256::bound(current, min, max, state.test_runner()) else {
-            bail!("cannot bound {current} in [{min}, {max}] range")
+            {
+                bail!("cannot bound {current} in [{min}, {max}] range");
+            }
         };
         Ok(mutated.abi_encode())
     }
@@ -89,7 +91,9 @@ impl Cheatcode for bound_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { current, min, max } = *self;
         let Some(mutated) = I256::bound(current, min, max, state.test_runner()) else {
-            bail!("cannot bound {current} in [{min}, {max}] range")
+            {
+                bail!("cannot bound {current} in [{min}, {max}] range");
+            }
         };
         Ok(mutated.abi_encode())
     }
@@ -224,7 +228,9 @@ impl Cheatcode for interceptInitcodeCall {
         if !state.intercept_next_create_call {
             state.intercept_next_create_call = true;
         } else {
-            bail!("vm.interceptInitcode() has already been called")
+            {
+                bail!("vm.interceptInitcode() has already been called");
+            }
         }
         Ok(Default::default())
     }

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -76,7 +76,9 @@ pub fn format_source(source: &str, config: FormatterConfig) -> eyre::Result<Stri
 
             Ok(formatted_source)
         }
-        Err(_) => eyre::bail!("Formatter could not parse source!"),
+        Err(_) => {
+            eyre::bail!("Formatter could not parse source!");
+        }
     }
 }
 
@@ -131,7 +133,9 @@ impl ChiselDispatcher {
         if let Some(command) = input.strip_prefix(COMMAND_LEADER) {
             return match ChiselCommand::parse(command) {
                 Ok(cmd) => self.dispatch_command(cmd).await,
-                Err(e) => eyre::bail!("unrecognized command: {e}"),
+                Err(e) => {
+                    eyre::bail!("unrecognized command: {e}");
+                }
             };
         }
 
@@ -411,7 +415,7 @@ impl ChiselDispatcher {
                 sh_println!("Set calldata to '{}'", arg.yellow())
             }
             Err(e) => {
-                eyre::bail!("Invalid calldata: {e}")
+                eyre::bail!("Invalid calldata: {e}");
             }
         }
     }
@@ -521,7 +525,9 @@ impl ChiselDispatcher {
             return Ok(());
         }
 
-        eyre::bail!("Variable must exist within `run()` function.")
+        {
+            eyre::bail!("Variable must exist within `run()` function.");
+        }
     }
 }
 

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -857,9 +857,11 @@ impl Type {
                 // Because tuple types cannot be passed to `abi.encode`, we will only be
                 // receiving functions that have 0 or 1 return parameters here.
                 if func.returns.is_empty() {
-                    eyre::bail!(
-                        "This call expression does not return any values to inspect. Insert as statement."
-                    )
+                    {
+                        eyre::bail!(
+                            "This call expression does not return any values to inspect. Insert as statement."
+                        );
+                    }
                 }
 
                 // Empty return types check is done above
@@ -884,10 +886,14 @@ impl Type {
                     .find(|attr| matches!(attr, pt::FunctionAttribute::Mutability(_)))
                 {
                     if let pt::Mutability::Payable(_) = _mut {
-                        eyre::bail!("This function mutates state. Insert as a statement.")
+                        {
+                            eyre::bail!("This function mutates state. Insert as a statement.");
+                        }
                     }
                 } else {
-                    eyre::bail!("This function mutates state. Insert as a statement.")
+                    {
+                        eyre::bail!("This function mutates state. Insert as a statement.");
+                    }
                 }
 
                 Ok(Self::ethabi(return_ty, Some(intermediate)))
@@ -904,9 +910,11 @@ impl Type {
                     .collect::<Result<Vec<_>>>()?;
                 Ok(Some(DynSolType::Tuple(inner_types)))
             } else {
-                eyre::bail!(
-                    "Could not find any definition in contract \"{contract_name}\" for type: {custom_type:?}"
-                )
+                {
+                    eyre::bail!(
+                        "Could not find any definition in contract \"{contract_name}\" for type: {custom_type:?}"
+                    );
+                }
             }
         } else {
             // Check if the custom type is a variable or function within the REPL contract before
@@ -1249,7 +1257,9 @@ fn unit_multiplier(unit: &Option<pt::Identifier>) -> Result<U256> {
             "wei" => 1,
             "gwei" => 10_usize.pow(9),
             "ether" => 10_usize.pow(18),
-            other => eyre::bail!("unknown unit: {other}"),
+            other => {
+                eyre::bail!("unknown unit: {other}");
+            }
         };
         Ok(U256::from(mul))
     } else {

--- a/crates/chisel/src/source.rs
+++ b/crates/chisel/src/source.rs
@@ -217,7 +217,9 @@ impl IntermediateOutput {
             .ok_or_else(|| eyre::eyre!("Could not find run function body!"))?
         {
             pt::Statement::Block { statements, .. } => Ok(statements),
-            _ => eyre::bail!("Could not find statements within run function body!"),
+            _ => {
+                eyre::bail!("Could not find statements within run function body!");
+            }
         }
     }
 }

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -25,7 +25,9 @@ impl FromStr for CliAuthorizationList {
         } else if let Ok(auth) = SignedAuthorization::decode(&mut hex::decode(s)?.as_ref()) {
             Ok(Self::Signed(auth))
         } else {
-            eyre::bail!("Failed to decode authorization")
+            {
+                eyre::bail!("Failed to decode authorization");
+            }
         }
     }
 }

--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -35,7 +35,9 @@ pub async fn parse_function_args<P: Provider<AnyNetwork>>(
     etherscan_api_key: Option<&str>,
 ) -> Result<(Vec<u8>, Option<Function>)> {
     if sig.trim().is_empty() {
-        eyre::bail!("Function signature or calldata must be provided.")
+        {
+            eyre::bail!("Function signature or calldata must be provided.");
+        }
     }
 
     let args = resolve_name_args(&args, provider).await;

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -58,7 +58,9 @@ pub fn remove_contract(
         Did you mean `{suggestion}`?"#
             );
         }
-        eyre::bail!(err)
+        {
+            eyre::bail!(err);
+        }
     };
 
     let abi = contract
@@ -88,10 +90,12 @@ pub fn get_cached_entry_by_name(
         for artifact_name in entry.artifacts.keys() {
             if artifact_name == name {
                 if cached_entry.is_some() {
-                    eyre::bail!(
-                        "contract with duplicate name `{}`. please pass the path instead",
-                        name
-                    )
+                    {
+                        eyre::bail!(
+                            "contract with duplicate name `{}`. please pass the path instead",
+                            name
+                        );
+                    }
                 }
                 cached_entry = Some((abs_path.to_owned(), entry.to_owned()));
             } else {
@@ -112,7 +116,9 @@ pub fn get_cached_entry_by_name(
         Did you mean `{suggestion}`?"#
         );
     }
-    eyre::bail!(err)
+    {
+        eyre::bail!(err);
+    }
 }
 
 /// Returns error if constructor has arguments.

--- a/crates/common/fmt/src/dynamic.rs
+++ b/crates/common/fmt/src/dynamic.rs
@@ -219,7 +219,9 @@ pub fn serialize_value_as_json(value: DynSolValue) -> Result<Value> {
         DynSolValue::Tuple(values) => Ok(Value::Array(
             values.into_iter().map(serialize_value_as_json).collect::<Result<_>>()?,
         )),
-        DynSolValue::Function(_) => eyre::bail!("cannot serialize function pointer"),
+        DynSolValue::Function(_) => {
+            eyre::bail!("cannot serialize function pointer");
+        }
     }
 }
 

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -16,7 +16,13 @@ where
     let args: Vec<S> = args.into_iter().collect();
 
     if inputs.len() != args.len() {
-        eyre::bail!("encode length mismatch: expected {} types, got {}", inputs.len(), args.len())
+        {
+            eyre::bail!(
+                "encode length mismatch: expected {} types, got {}",
+                inputs.len(),
+                args.len()
+            );
+        }
     }
 
     std::iter::zip(inputs, args)
@@ -92,7 +98,9 @@ pub fn abi_decode_calldata(
 
     // in case the decoding worked but nothing was decoded
     if res.is_empty() {
-        eyre::bail!("no data was decoded")
+        {
+            eyre::bail!("no data was decoded");
+        }
     }
 
     Ok(res)

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -217,7 +217,9 @@ impl ProjectCompiler {
         })?;
 
         if bail && output.has_compiler_errors() {
-            eyre::bail!("{output}")
+            {
+                eyre::bail!("{output}");
+            }
         }
 
         if !quiet {

--- a/crates/common/src/errors/mod.rs
+++ b/crates/common/src/errors/mod.rs
@@ -48,8 +48,12 @@ fn all_sources<E: private::ErrorChain + ?Sized>(err: &E) -> Vec<String> {
 pub fn convert_solar_errors(dcx: &solar::interface::diagnostics::DiagCtxt) -> eyre::Result<()> {
     match dcx.emitted_errors() {
         Some(Ok(())) => Ok(()),
-        Some(Err(e)) if !e.is_empty() => eyre::bail!("solar run failed:\n\n{e}"),
-        _ if dcx.has_errors().is_err() => eyre::bail!("solar run failed"),
+        Some(Err(e)) if !e.is_empty() => {
+            eyre::bail!("solar run failed:\n\n{e}");
+        }
+        _ if dcx.has_errors().is_err() => {
+            eyre::bail!("solar run failed");
+        }
         _ => Ok(()),
     }
 }

--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -124,7 +124,9 @@ impl OpenChainClient {
 
     fn ensure_not_spurious(&self) -> eyre::Result<()> {
         if self.is_spurious() {
-            eyre::bail!("Spurious connection detected")
+            {
+                eyre::bail!("Spurious connection detected");
+            }
         }
         Ok(())
     }
@@ -173,7 +175,9 @@ impl OpenChainClient {
         let text = self.get_text(url).await?;
         let SignatureResponse { ok, result } = match serde_json::from_str(&text) {
             Ok(response) => response,
-            Err(err) => eyre::bail!("could not decode response: {err}: {text}"),
+            Err(err) => {
+                eyre::bail!("could not decode response: {err}: {text}");
+            }
         };
         if !ok {
             eyre::bail!("OpenChain returned an error: {text}");
@@ -211,10 +215,12 @@ impl OpenChainClient {
     pub async fn decode_calldata(&self, calldata: &str) -> eyre::Result<OpenChainSignatures> {
         let calldata = calldata.strip_prefix("0x").unwrap_or(calldata);
         if calldata.len() < 8 {
-            eyre::bail!(
-                "Calldata too short: expected at least 8 characters (excluding 0x prefix), got {}.",
-                calldata.len()
-            )
+            {
+                eyre::bail!(
+                    "Calldata too short: expected at least 8 characters (excluding 0x prefix), got {}.",
+                    calldata.len()
+                );
+            }
         }
 
         let mut sigs = self.decode_function_selector(calldata[..8].parse().unwrap()).await?;
@@ -265,7 +271,9 @@ impl OpenChainClient {
         let (_, data) = calldata.split_at(8);
 
         if !data.len().is_multiple_of(64) {
-            eyre::bail!("\nInvalid calldata size")
+            {
+                eyre::bail!("\nInvalid calldata size");
+            }
         }
 
         let row_length = data.len() / 64;

--- a/crates/common/src/transactions.rs
+++ b/crates/common/src/transactions.rs
@@ -66,10 +66,14 @@ impl TransactionReceiptWithRevertReason {
             call_request.set_from(transaction.inner().inner.signer());
             match provider.call(call_request).block(BlockId::Hash(block_hash.into())).await {
                 Err(e) => return Ok(extract_revert_reason(e.to_string())),
-                Ok(_) => eyre::bail!("no revert reason as transaction succeeded"),
+                Ok(_) => {
+                    eyre::bail!("no revert reason as transaction succeeded");
+                }
             }
         }
-        eyre::bail!("unable to fetch block_hash")
+        {
+            eyre::bail!("unable to fetch block_hash");
+        }
     }
 }
 

--- a/crates/doc/src/preprocessor/deployments.rs
+++ b/crates/doc/src/preprocessor/deployments.rs
@@ -49,7 +49,9 @@ impl Preprocessor for Deployments {
                         .into_string()
                         .map_err(|e| eyre::eyre!("failed to extract directory name: {e:?}"))
                 } else {
-                    eyre::bail!("not a directory: {}", path.display())
+                    {
+                        eyre::bail!("not a directory: {}", path.display());
+                    }
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1363,9 +1363,17 @@ impl DatabaseExt for Backend {
             if self.inner.issued_local_fork_ids.contains_key(&id) {
                 return Ok(id);
             }
-            eyre::bail!("Requested fork `{}` does not exit", id)
+            {
+                eyre::bail!("Requested fork `{}` does not exit", id);
+            }
         }
-        if let Some(id) = self.active_fork_id() { Ok(id) } else { eyre::bail!("No fork active") }
+        if let Some(id) = self.active_fork_id() {
+            Ok(id)
+        } else {
+            {
+                eyre::bail!("No fork active");
+            }
+        }
     }
 
     fn ensure_fork_id(&self, id: LocalForkId) -> eyre::Result<&ForkId> {

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -48,7 +48,9 @@ pub async fn environment<N: Network, P: Provider<N>>(
                  latest block number: {latest_block}"
             );
         }
-        eyre::bail!("failed to get block for block number: {block_number}")
+        {
+            eyre::bail!("failed to get block for block number: {block_number}");
+        }
     };
 
     let cfg = configure_env(

--- a/crates/evm/traces/src/identifier/etherscan.rs
+++ b/crates/evm/traces/src/identifier/etherscan.rs
@@ -82,7 +82,9 @@ impl EtherscanIdentifier {
                 let output = project.compile()?;
 
                 if output.has_compiler_errors() {
-                    eyre::bail!("{output}")
+                    {
+                        eyre::bail!("{output}");
+                    }
                 }
 
                 Ok((project, output, root))

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -888,7 +888,9 @@ impl<'a, W: Write> Formatter<'a, W> {
             single_line = match fun(fmt) {
                 Ok(()) => true,
                 Err(FormatterError::Fmt(_)) => false,
-                Err(err) => bail!(err),
+                Err(err) => {
+                    bail!(err);
+                }
             };
             Ok(())
         })?;
@@ -905,7 +907,9 @@ impl<'a, W: Write> Formatter<'a, W> {
             single_line = match fun(fmt) {
                 Ok(()) => true,
                 Err(FormatterError::Fmt(_)) => false,
-                Err(err) => bail!(err),
+                Err(err) => {
+                    bail!(err);
+                }
             };
             Ok(())
         })?;
@@ -1754,7 +1758,9 @@ impl<'a, W: Write> Formatter<'a, W> {
             || !self.try_on_single_line(|fmt| {
                 write_attributes(fmt, false)?;
                 if !fmt.will_it_fit(if func.body.is_some() { " {" } else { ";" }) {
-                    bail!(FormatterError::fmt())
+                    {
+                        bail!(FormatterError::fmt());
+                    }
                 }
                 Ok(())
             })?;
@@ -1792,7 +1798,9 @@ impl<'a, W: Write> Formatter<'a, W> {
             && self.should_attempt_block_single_line(if_branch.as_mut(), cond_close_paren_loc);
         let if_branch_is_single_line = self.visit_stmt_as_block(if_branch, attempt_single_line)?;
         if single_line_stmt_wide && !if_branch_is_single_line {
-            bail!(FormatterError::fmt())
+            {
+                bail!(FormatterError::fmt());
+            }
         }
 
         if let Some(else_branch) = else_branch {
@@ -1807,7 +1815,9 @@ impl<'a, W: Write> Formatter<'a, W> {
                 let else_branch_is_single_line =
                     self.visit_stmt_as_block(else_branch, attempt_single_line)?;
                 if single_line_stmt_wide && !else_branch_is_single_line {
-                    bail!(FormatterError::fmt())
+                    {
+                        bail!(FormatterError::fmt());
+                    }
                 }
             }
         }
@@ -3061,7 +3071,9 @@ impl<W: Write> Visitor for Formatter<'_, W> {
             stmt_fits_on_single = match fmt.write_if_stmt(loc, cond, if_branch, else_branch) {
                 Ok(()) => true,
                 Err(FormatterError::Fmt(_)) => false,
-                Err(err) => bail!(err),
+                Err(err) => {
+                    bail!(err);
+                }
             };
             Ok(())
         })?;

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -90,7 +90,9 @@ impl BuildArgs {
                 files.extend(source_files_iter(path, MultiCompilerLanguage::FILE_EXTENSIONS));
             }
             if files.is_empty() {
-                eyre::bail!("No source files found in specified build paths.")
+                {
+                    eyre::bail!("No source files found in specified build paths.");
+                }
             }
         }
 

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -138,10 +138,12 @@ impl CreateArgs {
                     })
                     .collect::<Vec<String>>()
                     .join("\n");
-                eyre::bail!(
-                    "Dynamic linking not supported in `create` command - deploy the following library contracts first, then provide the address to link at compile time\n{}",
-                    link_refs
-                )
+                {
+                    eyre::bail!(
+                        "Dynamic linking not supported in `create` command - deploy the following library contracts first, then provide the address to link at compile time\n{}",
+                        link_refs
+                    );
+                }
             }
         };
 
@@ -282,7 +284,9 @@ impl CreateArgs {
     ) -> Result<()> {
         let bin = bin.into_bytes().unwrap_or_default();
         if bin.is_empty() {
-            eyre::bail!("no bytecode found in bin object for {}", self.contract.name)
+            {
+                eyre::bail!("no bytecode found in bin object for {}", self.contract.name);
+            }
         }
 
         let provider = Arc::new(provider);

--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -113,7 +113,9 @@ impl SelectorsSubcommands {
                 let project = build_args.project()?;
                 let output = if let Some(contract_info) = &contract {
                     let Some(contract_name) = contract_info.name() else {
-                        eyre::bail!("No contract name provided.")
+                        {
+                            eyre::bail!("No contract name provided.");
+                        }
                     };
 
                     let target_path = contract_info

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -80,11 +80,13 @@ fn parse_verification_result(cmd: &mut TestCommand, retries: u32) -> eyre::Resul
         if out.contains("Contract successfully verified") {
             return Ok(());
         }
-        eyre::bail!(
-            "Failed to get verification, stdout: {}, stderr: {}",
-            out,
-            String::from_utf8_lossy(&output.stderr)
-        )
+        {
+            eyre::bail!(
+                "Failed to get verification, stdout: {}, stderr: {}",
+                out,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
     })
 }
 

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -88,14 +88,16 @@ impl TestConfig {
                     .await
                     .into_iter()
                     .collect::<Vec<String>>();
-                    eyre::bail!(
-                        "Test {} did not {} as expected.\nReason: {:?}\nLogs:\n{}\n\nTraces:\n{}",
-                        test_name,
-                        outcome,
-                        result.reason,
-                        logs.join("\n"),
-                        decoded_traces.into_iter().format("\n"),
-                    )
+                    {
+                        eyre::bail!(
+                            "Test {} did not {} as expected.\nReason: {:?}\nLogs:\n{}\n\nTraces:\n{}",
+                            test_name,
+                            outcome,
+                            result.reason,
+                            logs.join("\n"),
+                            decoded_traces.into_iter().format("\n"),
+                        );
+                    }
                 }
             }
         }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -229,13 +229,15 @@ pub async fn send_transaction(
                     Ordering::Greater => {
                         bail!(
                             "EOA nonce changed unexpectedly while sending transactions. Expected {tx_nonce} got {nonce} from provider."
-                        )
+                        );
                     }
                     Ordering::Less => {
                         if attempt == 4 {
-                            bail!(
-                                "After 5 attempts, provider nonce ({nonce}) is still behind expected nonce ({tx_nonce})."
-                            )
+                            {
+                                bail!(
+                                    "After 5 attempts, provider nonce ({nonce}) is still behind expected nonce ({tx_nonce})."
+                                );
+                            }
                         }
                         warn!(
                             "Expected nonce ({tx_nonce}) is ahead of provider nonce ({nonce}). Retrying in 1 second..."
@@ -308,7 +310,9 @@ impl SendTransactionsKind {
         match self {
             Self::Unlocked(unlocked) => {
                 if !unlocked.contains(addr) {
-                    bail!("Sender address {:?} is not unlocked", addr)
+                    {
+                        bail!("Sender address {:?} is not unlocked", addr);
+                    }
                 }
                 Ok(SendTransactionKind::Unlocked(tx))
             }
@@ -316,7 +320,9 @@ impl SendTransactionsKind {
                 if let Some(wallet) = wallets.get(addr) {
                     Ok(SendTransactionKind::Raw(tx, wallet))
                 } else {
-                    bail!("No matching signer for {:?} found", addr)
+                    {
+                        bail!("No matching signer for {:?} found", addr);
+                    }
                 }
             }
         }

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -217,9 +217,11 @@ impl PreprocessedState {
                 let target_name = target.name.split('.').next().unwrap();
                 let id_name = id.name.split('.').next().unwrap();
                 if target_name != id_name {
-                    eyre::bail!(
-                        "Multiple contracts in the target path. Please specify the contract name with `--tc ContractName`"
-                    )
+                    {
+                        eyre::bail!(
+                            "Multiple contracts in the target path. Please specify the contract name with `--tc ContractName`"
+                        );
+                    }
                 }
             }
             target_id = Some(id);

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -303,9 +303,11 @@ impl ExecutedState {
         if rpc_data.is_multi_chain() {
             sh_warn!("Multi chain deployment is still under development. Use with caution.")?;
             if !self.build_data.libraries.is_empty() {
-                eyre::bail!(
-                    "Multi chain deployment does not support library linking at the moment."
-                )
+                {
+                    eyre::bail!(
+                        "Multi chain deployment does not support library linking at the moment."
+                    );
+                }
             }
         }
         rpc_data.check_shanghai_support().await?;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -391,12 +391,16 @@ impl ScriptArgs {
             let matching_functions =
                 abi.functions().filter(|func| func.name == self.sig).collect::<Vec<_>>();
             match matching_functions.len() {
-                0 => eyre::bail!("Function `{}` not found in the ABI", self.sig),
+                0 => {
+                    eyre::bail!("Function `{}` not found in the ABI", self.sig);
+                }
                 1 => matching_functions[0],
-                2.. => eyre::bail!(
-                    "Multiple functions with the same name `{}` found in the ABI",
-                    self.sig
-                ),
+                2.. => {
+                    eyre::bail!(
+                        "Multiple functions with the same name `{}` found in the ABI",
+                        self.sig
+                    );
+                }
             }
         };
         let data = encode_function_args(func, &self.args)?;

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -271,7 +271,9 @@ impl ScriptRunner {
                     sh_err!("Failed with `{reason}`:\n")?;
                     (Address::ZERO, raw)
                 }
-                Err(e) => eyre::bail!("Failed deploying contract: {e:?}"),
+                Err(e) => {
+                    eyre::bail!("Failed deploying contract: {e:?}");
+                }
             };
 
             Ok(ScriptResult {

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -202,7 +202,9 @@ impl PreSimulationState {
         }
 
         if abort {
-            eyre::bail!("Simulated execution failed.")
+            {
+                eyre::bail!("Simulated execution failed.");
+            }
         }
 
         Ok(final_txs)

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -318,14 +318,18 @@ impl VerifyBytecodeArgs {
         let transaction = provider
             .get_transaction_by_hash(creation_data.transaction_hash)
             .await
-            .or_else(|e| eyre::bail!("Couldn't fetch transaction from RPC: {:?}", e))?
+            .or_else(|e| {
+                eyre::bail!("Couldn't fetch transaction from RPC: {:?}", e);
+            })?
             .ok_or_else(|| {
                 eyre::eyre!("Transaction not found for hash {}", creation_data.transaction_hash)
             })?;
         let receipt = provider
             .get_transaction_receipt(creation_data.transaction_hash)
             .await
-            .or_else(|e| eyre::bail!("Couldn't fetch transaction receipt from RPC: {:?}", e))?;
+            .or_else(|e| {
+                eyre::bail!("Couldn't fetch transaction receipt from RPC: {:?}", e);
+            })?;
         let receipt = if let Some(receipt) = receipt {
             receipt
         } else {
@@ -439,12 +443,14 @@ impl VerifyBytecodeArgs {
             // Get contract creation block.
             let simulation_block = match self.block {
                 Some(BlockId::Number(BlockNumberOrTag::Number(block))) => block,
-                Some(_) => eyre::bail!("Invalid block number"),
+                Some(_) => {
+                    eyre::bail!("Invalid block number");
+                }
                 None => {
                     let provider = utils::get_provider(&config)?;
                     provider
                     .get_transaction_by_hash(creation_data.transaction_hash)
-                    .await.or_else(|e| eyre::bail!("Couldn't fetch transaction from RPC: {:?}", e))?.ok_or_else(|| {
+                    .await.or_else(|e| { eyre::bail!("Couldn't fetch transaction from RPC: {:?}", e); })?.ok_or_else(|| {
                         eyre::eyre!("Transaction not found for hash {}", creation_data.transaction_hash)
                     })?
                     .0.inner.block_number.ok_or_else(|| {

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -420,9 +420,11 @@ impl EtherscanVerificationProvider {
         } else if transaction.to() == Some(DEFAULT_CREATE2_DEPLOYER) {
             &transaction.0.inner.input()[32..]
         } else {
-            eyre::bail!(
-                "Fetching of constructor arguments is not supported for contracts created by contracts"
-            )
+            {
+                eyre::bail!(
+                    "Fetching of constructor arguments is not supported for contracts created by contracts"
+                );
+            }
         };
 
         let output = context.project.compile_file(&context.target_path)?;
@@ -446,7 +448,9 @@ impl EtherscanVerificationProvider {
             sh_println!("Identified constructor arguments: {constructor_args}")?;
             Ok(constructor_args)
         } else {
-            eyre::bail!("Local bytecode doesn't match on-chain bytecode")
+            {
+                eyre::bail!("Local bytecode doesn't match on-chain bytecode");
+            }
         }
     }
 }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -190,10 +190,14 @@ impl VerificationProviderType {
             if let Some(chain) = chain
                 && chain.etherscan_urls().is_none()
             {
-                eyre::bail!(EtherscanConfigError::UnknownChain(String::new(), chain))
+                {
+                    eyre::bail!(EtherscanConfigError::UnknownChain(String::new(), chain));
+                }
             }
             if !has_key {
-                eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier")
+                {
+                    eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier");
+                }
             }
             return Ok(Box::<EtherscanVerificationProvider>::default());
         }
@@ -213,9 +217,11 @@ impl VerificationProviderType {
         }
 
         // 5. If no valid provider is specified, bail.
-        eyre::bail!(
-            "No valid verification provider specified. Pass the --verifier flag to specify a provider or set the ETHERSCAN_API_KEY environment variable to use Etherscan as a verifier."
-        )
+        {
+            eyre::bail!(
+                "No valid verification provider specified. Pass the --verifier flag to specify a provider or set the ETHERSCAN_API_KEY environment variable to use Etherscan as a verifier."
+            );
+        }
     }
 
     pub fn is_sourcify(&self) -> bool {

--- a/crates/verify/src/types.rs
+++ b/crates/verify/src/types.rs
@@ -20,7 +20,9 @@ impl FromStr for VerificationType {
         match s {
             "full" => Ok(Self::Full),
             "partial" => Ok(Self::Partial),
-            _ => eyre::bail!("Invalid verification type"),
+            _ => {
+                eyre::bail!("Invalid verification type");
+            }
         }
     }
 }

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -109,7 +109,9 @@ pub fn build_using_cache(
         let version = etherscan_settings.compiler_version.to_owned();
         // Ignores vyper
         if version.starts_with("vyper:") {
-            eyre::bail!("Vyper contracts are not supported")
+            {
+                eyre::bail!("Vyper contracts are not supported");
+            }
         }
         // Parse etherscan version string
         let version = version.split('+').next().unwrap_or("").trim_start_matches('v').to_string();
@@ -137,7 +139,9 @@ pub fn build_using_cache(
         }
     }
 
-    eyre::bail!("couldn't find cached artifact for contract {}", args.contract.name)
+    {
+        eyre::bail!("couldn't find cached artifact for contract {}", args.contract.name);
+    }
 }
 
 pub fn print_result(
@@ -258,7 +262,9 @@ pub fn maybe_predeploy_contract(
             maybe_predeploy = true;
             Ok((None, maybe_predeploy))
         }
-        Err(e) => eyre::bail!("Error fetching creation data from verifier-url: {:?}", e),
+        Err(e) => {
+            eyre::bail!("Error fetching creation data from verifier-url: {:?}", e);
+        }
     }
 }
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -208,9 +208,11 @@ impl VerifyArgs {
         let config = self.load_config()?;
 
         if self.guess_constructor_args && config.get_rpc_url().is_none() {
-            eyre::bail!(
-                "You have to provide a valid RPC URL to use --guess-constructor-args feature"
-            )
+            {
+                eyre::bail!(
+                    "You have to provide a valid RPC URL to use --guess-constructor-args feature"
+                );
+            }
         }
 
         // If chain is not set, we try to get it from the RPC.
@@ -328,16 +330,20 @@ impl VerifyArgs {
                         "Ambiguous compiler versions found in cache: {}",
                         unique_versions.iter().join(", ")
                     );
-                    eyre::bail!(
-                        "Compiler version has to be set in `foundry.toml`. If the project was not deployed with foundry, specify the version through `--compiler-version` flag."
-                    )
+                    {
+                        eyre::bail!(
+                            "Compiler version has to be set in `foundry.toml`. If the project was not deployed with foundry, specify the version through `--compiler-version` flag."
+                        );
+                    }
                 }
 
                 unique_versions.into_iter().next().unwrap().to_owned()
             } else {
-                eyre::bail!(
-                    "If cache is disabled, compiler version must be either provided with `--compiler-version` option or set in foundry.toml"
-                )
+                {
+                    eyre::bail!(
+                        "If cache is disabled, compiler version must be either provided with `--compiler-version` option or set in foundry.toml"
+                    );
+                }
             };
 
             let settings = if let Some(profile) = &self.compilation_profile {
@@ -346,7 +352,9 @@ impl VerifyArgs {
                 } else if let Some(settings) = project.additional_settings.get(profile.as_str()) {
                     settings
                 } else {
-                    eyre::bail!("Unknown compilation profile: {}", profile)
+                    {
+                        eyre::bail!("Unknown compilation profile: {}", profile);
+                    }
                 }
             } else if let Some((cache, entry)) = cache
                 .as_ref()
@@ -381,10 +389,12 @@ impl VerifyArgs {
                         version
                     );
                 } else if profiles.len() > 1 {
-                    eyre::bail!(
-                        "Ambiguous compilation profiles found in cache: {}, please specify the profile through `--compilation-profile` flag",
-                        profiles.iter().join(", ")
-                    )
+                    {
+                        eyre::bail!(
+                            "Ambiguous compilation profiles found in cache: {}, please specify the profile through `--compilation-profile` flag",
+                            profiles.iter().join(", ")
+                        );
+                    }
                 }
 
                 let profile = profiles.into_iter().next().unwrap().to_owned();
@@ -392,9 +402,11 @@ impl VerifyArgs {
             } else if project.additional_settings.is_empty() {
                 &project.settings
             } else {
-                eyre::bail!(
-                    "If cache is disabled, compilation profile must be provided with `--compiler-version` option or set in foundry.toml"
-                )
+                {
+                    eyre::bail!(
+                        "If cache is disabled, compilation profile must be provided with `--compiler-version` option or set in foundry.toml"
+                    );
+                }
             };
 
             VerificationContext::new(
@@ -406,7 +418,9 @@ impl VerifyArgs {
             )
         } else {
             if config.get_rpc_url().is_none() {
-                eyre::bail!("You have to provide a contract name or a valid RPC URL")
+                {
+                    eyre::bail!("You have to provide a contract name or a valid RPC URL");
+                }
             }
             let provider = utils::get_provider(&config)?;
             let code = provider.get_code_at(self.address).await?;
@@ -417,10 +431,12 @@ impl VerifyArgs {
             );
 
             let Some((artifact_id, _)) = contracts.find_by_deployed_code_exact(&code) else {
-                eyre::bail!(format!(
-                    "Bytecode at {} does not match any local contracts",
-                    self.address
-                ))
+                {
+                    eyre::bail!(format!(
+                        "Bytecode at {} does not match any local contracts",
+                        self.address
+                    ));
+                }
             };
 
             let settings = project

--- a/crates/wallets/src/utils.rs
+++ b/crates/wallets/src/utils.rs
@@ -21,13 +21,17 @@ fn ensure_pk_not_env(pk: &str) -> Result<()> {
 pub fn create_private_key_signer(private_key_str: &str) -> Result<WalletSigner> {
     let Ok(private_key) = B256::from_hex(private_key_str) else {
         ensure_pk_not_env(private_key_str)?;
-        eyre::bail!("Failed to decode private key")
+        {
+            eyre::bail!("Failed to decode private key");
+        }
     };
     match PrivateKeySigner::from_bytes(&private_key) {
         Ok(pk) => Ok(WalletSigner::Local(pk)),
         Err(err) => {
             ensure_pk_not_env(private_key_str)?;
-            eyre::bail!("Failed to create wallet from private key: {err}")
+            {
+                eyre::bail!("Failed to create wallet from private key: {err}");
+            }
         }
     }
 }
@@ -111,13 +115,17 @@ pub fn create_keystore_signer(
     maybe_password_file: Option<&str>,
 ) -> Result<(Option<WalletSigner>, Option<PendingSigner>)> {
     if !path.exists() {
-        eyre::bail!("Keystore file `{path:?}` does not exist")
+        {
+            eyre::bail!("Keystore file `{path:?}` does not exist");
+        }
     }
 
     if path.is_dir() {
-        eyre::bail!(
-            "Keystore path `{path:?}` is a directory. Please specify the keystore file directly."
-        )
+        {
+            eyre::bail!(
+                "Keystore path `{path:?}` is a directory. Please specify the keystore file directly."
+            );
+        }
     }
 
     let password = match (maybe_password, maybe_password_file) {

--- a/crates/wallets/src/wallet.rs
+++ b/crates/wallets/src/wallet.rs
@@ -153,7 +153,7 @@ or RPC that has unlocked accounts, the --unlocked or --ethsign flags can be used
 respectively. The sender address can be specified by setting the `ETH_FROM` environment
 variable to the desired unlocked account address, or by providing the address directly
 using the --from flag."
-            )
+            );
         };
 
         Ok(signer)


### PR DESCRIPTION
latest cargo nightly version's clippy complains about eyre. Fixed everywhere.