### PR TITLE
ci: fix claude review

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,3 +1,23 @@
+---
+name: pr-review
+description: Review a seismic-foundry pull request (or, with no argument, the local diff before a PR exists) following the team review guidelines. Used by the Claude PR review CI workflow (.github/workflows/claude.yml) and invocable locally.
+argument-hint: [pr-number]
+disable-model-invocation: true
+---
+
+Review the following changes: $ARGUMENTS
+
+Determine what to review from the argument above:
+
+- **A PR number**: run `gh pr diff <number>` to get the diff, and `gh pr view <number>` for the description and discussion. This is how CI invokes the skill.
+- **No argument** (local pre-PR review): diff the current branch against the base branch with `git diff origin/seismic...HEAD`, then `git diff HEAD` for uncommitted changes and `git status` to catch untracked new files (Read those directly). There is no PR description or discussion in this mode — skip the guideline steps that reference them.
+
+Then:
+
+1. Review ONLY the changed files following the guidelines below.
+2. Output your review as plain text. Do NOT post comments yourself.
+3. If the diff touches Seismic-specific code, use Read and Grep to follow key imports and verify semantic correctness.
+
 # Claude PR Review Guidelines
 
 You're a code reviewer helping engineers ship better code. Your feedback should be high-signal: every comment should prevent a bug, improve safety, or teach something valuable.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,12 +3,26 @@
 # Runs Claude in agent mode to review PRs, then posts the review as a
 # sticky comment (one comment, edited in-place on each push).
 #
+# The review guidelines live in the .claude/skills/pr-review/ skill,
+# which the prompt invokes as /pr-review. The same skill can be run
+# locally in any Claude Code session: `/pr-review <pr-number>`, or
+# `/pr-review` with no argument to review local changes before a PR.
+#
 # Agent mode doesn't post comments itself, so a post-step extracts
 # Claude's text output from the execution file and manages the comment.
+#
+# NOTE: Anthropic ships a managed alternative to this whole workflow —
+# https://code.claude.com/docs/en/code-review — multi-agent review with
+# a false-positive verification pass, inline comments by severity, and
+# customization via a repo-root REVIEW.md. Worth evaluating at some
+# point; keeping this simple self-hosted version for now.
 #
 # Requires: ANTHROPIC_API_KEY secret.
 
 name: Claude Code PR Review
+
+env:
+  CLAUDE_MODEL: claude-opus-4-8
 
 on:
   pull_request:
@@ -45,14 +59,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Read review prompt
-        id: prompt
+      # On pull_request events the checkout is the PR merge ref, so a PR
+      # could edit its own review guidelines. Pin the review skill to the
+      # base branch's copy (skipped if the base doesn't have it yet, e.g.
+      # the PR that introduces the skill).
+      - name: Pin review skill to base branch
+        if: github.event_name == 'pull_request'
         run: |
-          {
-            echo 'REVIEW_PROMPT<<EOF'
-            cat .claude/prompts/claude-pr-review.md
-            echo 'EOF'
-          } >> "$GITHUB_ENV"
+          if git cat-file -e "origin/${{ github.base_ref }}:.claude/skills/pr-review/SKILL.md" 2>/dev/null; then
+            git checkout "origin/${{ github.base_ref }}" -- .claude/skills/pr-review/
+          fi
 
       - uses: anthropics/claude-code-action@v1
         id: claude
@@ -60,16 +76,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model claude-sonnet-4-20250514
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
-          prompt: |
-            Review PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.
-
-            1. Run `gh pr diff ${{ env.PR_NUMBER }}` to get the diff.
-            2. Review ONLY the changed files following the guidelines below.
-            3. Output your review as plain text. Do NOT post comments yourself.
-
-            ${{ env.REVIEW_PROMPT }}
+            --model ${{ env.CLAUDE_MODEL }}
+            --allowedTools "Read,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
+          prompt: "/pr-review ${{ env.PR_NUMBER }}"
 
       - name: Post review comment
         if: always() && steps.claude.outputs.execution_file


### PR DESCRIPTION
Fixing this error:
<img width="919" height="161" alt="image" src="https://github.com/user-attachments/assets/48918657-032c-4cc5-9b4b-ff03041440b8" />


Copied same update I did to reth. Thinking we should probably have a centralized repo with these at some point, and the other repos can just pull from it so we don't have to duplicate like this everywhere.