### PR TITLE
fix(anvil): domain-separate request and response AES keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7309,7 +7309,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "revm",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -8503,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -8519,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8534,7 +8534,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -8547,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "either",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -8577,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "either",
@@ -8619,7 +8619,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8631,7 +8631,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -8666,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -9248,7 +9248,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=92d2c0a17808eca1a3b0123d02f8aad003ee1b55#92d2c0a17808eca1a3b0123d02f8aad003ee1b55"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9271,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=92d2c0a17808eca1a3b0123d02f8aad003ee1b55#92d2c0a17808eca1a3b0123d02f8aad003ee1b55"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=92d2c0a17808eca1a3b0123d02f8aad003ee1b55#92d2c0a17808eca1a3b0123d02f8aad003ee1b55"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=92d2c0a17808eca1a3b0123d02f8aad003ee1b55#92d2c0a17808eca1a3b0123d02f8aad003ee1b55"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9338,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=8274f14cbbad76daadad3aaa1d6d0418b3eeffc0#8274f14cbbad76daadad3aaa1d6d0418b3eeffc0"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=26fdf9f2823459c05b0d70b6c528e12ae32f7e11#26fdf9f2823459c05b0d70b6c528e12ae32f7e11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "seismic-prelude"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=92d2c0a17808eca1a3b0123d02f8aad003ee1b55#92d2c0a17808eca1a3b0123d02f8aad003ee1b55"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=daa7785558bc2f4522d667ff5021ef955145aca4#daa7785558bc2f4522d667ff5021ef955145aca4"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "hkdf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7309,7 +7309,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "revm",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -8503,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -8519,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8534,7 +8534,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -8547,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "either",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -8577,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "either",
@@ -8619,7 +8619,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8631,7 +8631,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -8666,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -9248,7 +9248,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9271,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9338,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=26fdf9f2823459c05b0d70b6c528e12ae32f7e11#26fdf9f2823459c05b0d70b6c528e12ae32f7e11"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "seismic-prelude"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "hkdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 # If our dependencies depend on these things,
 # then this will override whatever versions they point to
 # and instead use our local version
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "26fdf9f2823459c05b0d70b6c528e12ae32f7e11" }
 
 # seismic-alloy-core
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -390,21 +390,21 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # seismic-revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "daa7785558bc2f4522d667ff5021ef955145aca4" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "daa7785558bc2f4522d667ff5021ef955145aca4" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "daa7785558bc2f4522d667ff5021ef955145aca4" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "daa7785558bc2f4522d667ff5021ef955145aca4" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "daa7785558bc2f4522d667ff5021ef955145aca4" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "daa7785558bc2f4522d667ff5021ef955145aca4" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "025bdf5924af5aa966c5b349f1f11a6d3e547fa4" }
 
 # seismic-alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "92d2c0a17808eca1a3b0123d02f8aad003ee1b55" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "92d2c0a17808eca1a3b0123d02f8aad003ee1b55" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "92d2c0a17808eca1a3b0123d02f8aad003ee1b55" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "92d2c0a17808eca1a3b0123d02f8aad003ee1b55" }
-seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "92d2c0a17808eca1a3b0123d02f8aad003ee1b55" }
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
 
 # alloy-evm
 alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 # If our dependencies depend on these things,
 # then this will override whatever versions they point to
 # and instead use our local version
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "26fdf9f2823459c05b0d70b6c528e12ae32f7e11" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
 
 # seismic-alloy-core
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -390,21 +390,21 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # seismic-revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "025bdf5924af5aa966c5b349f1f11a6d3e547fa4" }
 
 # seismic-alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
-seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
 
 # alloy-evm
 alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -681,7 +681,7 @@ impl PendingTransaction {
                     // these two have already been validated in TransactionValidator,
                     // so we simply unwrap here
                     data: seismic_elements
-                        .decrypt(&tx_io_sk, &input, &tx_metadata)
+                        .decrypt_request(&tx_io_sk, &input, &tx_metadata)
                         .expect("failed to decrypt ciphertext")
                         .into(),
                     chain_id: Some(*chain_id),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2158,7 +2158,7 @@ impl Backend {
         let tx_io_sk = seismic_crypto::get_unsecure_sample_secp256k1_sk();
         if let Some(metadata) = &tx_metadata {
             let encrypted_input = request.inner.input.clone().input.unwrap_or(Bytes::new()).clone();
-            if let Err(e) = metadata.decrypt(&tx_io_sk, &encrypted_input) {
+            if let Err(e) = metadata.decrypt_request(&tx_io_sk, &encrypted_input) {
                 return Err(BlockchainError::Message(format!("Invalid AEAD metadata: {e}")));
             }
         }
@@ -2168,7 +2168,7 @@ impl Backend {
             .map(|plaintext_output| match tx_metadata {
                 Some(tx_metadata) => tx_metadata
                     .seismic_elements
-                    .encrypt(&tx_io_sk, &plaintext_output.data(), &tx_metadata)
+                    .encrypt_response(&tx_io_sk, &plaintext_output.data(), &tx_metadata)
                     .map_err(|e| {
                         BlockchainError::Message(format!("Failed to encrypt output: {}", e))
                     })
@@ -3808,7 +3808,7 @@ impl TransactionValidator for Backend {
             let tx_io_sk = seismic_crypto::get_unsecure_sample_secp256k1_sk();
             let _decrypted_data = inner
                 .seismic_elements
-                .decrypt(&tx_io_sk, &inner.input, &tx_metadata)
+                .decrypt_request(&tx_io_sk, &inner.input, &tx_metadata)
                 .map_err(|_e| {
                     InvalidTransactionError::SeismicDecryptionFailed(format!(
                         "Failed to decrypt seismic calldata"

--- a/crates/anvil/tests/it/seismic.rs
+++ b/crates/anvil/tests/it/seismic.rs
@@ -16,7 +16,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolValue, sol};
 use anvil::{NodeConfig, spawn};
 use secp256k1::{PublicKey, SecretKey};
-use seismic_crypto::aes_decrypt;
+use seismic_crypto::{AesKeyDomain, aes_decrypt, ecdh_decrypt_aead};
 use std::{fs, str::FromStr};
 
 use seismic_prelude::foundry::{
@@ -309,6 +309,18 @@ async fn test_seismic_transaction_rpc() {
         .client_decrypt(&res, &network_pubkey, &get_encryption_private_key(), &metadata)
         .unwrap();
     assert_eq!(Bytes::from(decrypted), test_utils::ContractTestContext::get_code());
+    assert!(
+        ecdh_decrypt_aead(
+            &network_pubkey,
+            &get_encryption_private_key(),
+            AesKeyDomain::TxRequest,
+            &res,
+            seismic_elements.get_enclave_nonce(),
+            &metadata.encode_as_aad(),
+        )
+        .is_err(),
+        "signed-read response must not decrypt with the request traffic key"
+    );
 
     let chain_id = provider.get_chain_id().await.unwrap();
 


### PR DESCRIPTION
## Summary

- advance seismic-crypto, seismic-revm, and seismic-alloy to the AES key-domain separation PR heads
- use explicit request decryption and response encryption APIs across transaction execution, signed calls, and pool validation
- verify a real signed-read response decrypts through the response path and fails under the request domain