### PR TITLE
feat(cheatcodes): add vm.txType(uint8) for testing isSeismicTx() gates

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -11194,6 +11194,26 @@
     },
     {
       "func": {
+        "id": "txType",
+        "description": "Sets the EIP-2718 transaction type for subsequent calls, so `txtype()` /\n`TxUtils.isSeismicTx()` can be exercised in tests (e.g. `74` for a Seismic tx).",
+        "declaration": "function txType(uint8 newTxType) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "txType(uint8)",
+        "selector": "0x032d1cc8",
+        "selectorBytes": [
+          3,
+          45,
+          28,
+          200
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "unixTime",
         "description": "Returns the time since unix epoch in milliseconds.",
         "declaration": "function unixTime() external view returns (uint256 milliseconds);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -531,6 +531,11 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Unsafe)]
     function txGasPrice(uint256 newGasPrice) external;
 
+    /// Sets the EIP-2718 transaction type for subsequent calls, so `txtype()` /
+    /// `TxUtils.isSeismicTx()` can be exercised in tests (e.g. `74` for a Seismic tx).
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function txType(uint8 newTxType) external;
+
     /// Sets `block.timestamp`.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function warp(uint256 newTimestamp) external;

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -555,6 +555,14 @@ impl Cheatcode for txGasPriceCall {
     }
 }
 
+impl Cheatcode for txTypeCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { newTxType } = self;
+        ccx.ecx.tx.tx_type = *newTxType;
+        Ok(Default::default())
+    }
+}
+
 impl Cheatcode for warpCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { newTimestamp } = self;

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -552,6 +552,7 @@ interface Vm {
     function trim(string calldata input) external pure returns (string memory output);
     function tryFfi(string[] calldata commandInput) external returns (FfiResult memory result);
     function txGasPrice(uint256 newGasPrice) external;
+    function txType(uint8 newTxType) external;
     function unixTime() external view returns (uint256 milliseconds);
     function warmSlot(address target, bytes32 slot) external;
     function warp(uint256 newTimestamp) external;


### PR DESCRIPTION
## Summary

Adds `vm.txType(uint8 newTxType)` — a cheatcode that sets the EIP-2718 transaction type on
the test tx env for subsequent calls, mirroring `vm.txGasPrice`. This lets contract authors
unit-test logic gated on the Seismic `txtype()` opcode / `TxUtils.isSeismicTx()` (e.g.
`vm.txType(74)` to simulate a Seismic transaction, `vm.txType(2)` for a standard one).

Without it, `sforge test` runs every call as a standard tx (type derived from
`minimal_tx_type()`), so `isSeismic()`-gated shielded functions can only be tested on one
branch. This closes that gap.

## Changes
- `crates/cheatcodes/spec/src/vm.rs` — `txType(uint8)` declaration.
- `crates/cheatcodes/src/evm.rs` — impl: `ccx.ecx.tx.tx_type = newTxType` (same mechanism as
  `txGasPrice`/blobhashes).
- Regenerated `crates/cheatcodes/assets/cheatcodes.json` + `testdata/cheats/Vm.sol`.

## Testing
Compiles on stock `seismic`; cheatcode spec/interface generation tests pass. End-to-end
verified with the Seismic std-lib `TxUtils` tests (seismic repo): `vm.txType(0x4A)` →
`isSeismicTx()==true` / `txType()==74`; `vm.txType(2)` → false/2 (requires a TXTYPE-capable
revm, i.e. after seismic-revm #224 + the pin bump).

## Context
Part of the TXTYPE feature (opcode: seismic-revm #224; builtin: seismic-solidity #392;
helper: seismic #214). See TXTYPE_REVIEW_HANDOFF.md.
