### PR TITLE
fix: download ssolc via the release redirect, not the GitHub REST API

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -66,13 +66,11 @@ jobs:
           shared-key: "test-cache"
       - name: Install ssolc
         run: |
-          # Fetch the latest release asset ID
-          ASSET_ID=$(curl -s https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/latest | \
-            jq -r '.assets[] | select(.name == "ssolc-linux-x86_64.tar.gz") | .id')
-          # Download the asset
-          curl -L -H "Accept: application/octet-stream" \
-            -o ssolc.tar.gz \
-            "https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/assets/$ASSET_ID"
+          # The releases/latest/download/<asset> redirect avoids the GitHub
+          # REST API, whose unauthenticated per-IP rate limit is routinely
+          # exhausted on shared CI runners (same fix as foundryup/foundryup)
+          curl -fL -o ssolc.tar.gz \
+            "https://github.com/SeismicSystems/seismic-solidity/releases/latest/download/ssolc-linux-x86_64.tar.gz"
           # Extract - the binary is at solc/solc inside the archive
           tar -xzf ssolc.tar.gz
           sudo mv solc/solc /usr/local/bin/ssolc

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -25,7 +25,6 @@ export RUSTFLAGS="${RUSTFLAGS:--C target-cpu=native}"
 main() {
   need_cmd git
   need_cmd curl
-  need_cmd jq
 
   while [[ -n $1 ]]; do
     case $1 in
@@ -440,22 +439,18 @@ install_ssolc() {
   TEMP_DIR=$(mktemp -d)
   trap 'rm -rf "$TEMP_DIR"' EXIT
 
-  # Download the release
-  echo "Fetching latest release information..."
-  GITHUB_API_URL="https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/latest"
-  ASSET_ID=$(curl -s "$GITHUB_API_URL" | \
-      jq -r --arg name "$TARGET_NAME" '.assets[] | select(.name == $name) | .id')
-
-  if [[ -z "$ASSET_ID" ]]; then
-    echo "Error: Asset $TARGET_NAME not found in the latest release."
-    exit 1
-  fi
-
+  # Download the release. The releases/latest/download/<asset> redirect
+  # resolves the latest release without the GitHub REST API, whose
+  # unauthenticated per-IP rate limit is routinely exhausted on shared CI
+  # runners (the API's JSON error body has no .assets, which used to
+  # surface here as "jq: Cannot iterate over null").
   echo "Downloading $TARGET_NAME..."
   DOWNLOAD_PATH="$TEMP_DIR/$TARGET_NAME"
-  curl -L -H "Accept: application/octet-stream" \
-       -o "$DOWNLOAD_PATH" \
-       "https://api.github.com/repos/SeismicSystems/seismic-solidity/releases/assets/$ASSET_ID"
+  DOWNLOAD_URL="https://github.com/SeismicSystems/seismic-solidity/releases/latest/download/$TARGET_NAME"
+  if ! curl -fL -o "$DOWNLOAD_PATH" "$DOWNLOAD_URL"; then
+    echo "Error: failed to download $TARGET_NAME from the latest seismic-solidity release."
+    exit 1
+  fi
 
   # Extract and install
   echo "Extracting archive..."


### PR DESCRIPTION
Both ssolc install paths resolved the latest seismic-solidity release through api.github.com: releases/latest to look up the asset ID, then the assets endpoint for the bytes. Both calls were unauthenticated, and GitHub's unauthenticated API quota is 60 requests/hour per source IP — shared CI runners routinely have it exhausted by other tenants, so the API returns a rate-limit JSON body with no .assets and the install died with "jq: Cannot iterate over null (null)" until the workflow was rerun on a luckier runner.

Fetch https://github.com/.../releases/latest/download/<asset> instead: the web redirect resolves the latest release and serves the asset from the release CDN with no REST API involvement and no rate limit, in one round trip. curl -f turns a missing asset into a clean error instead of saving an HTML error page.

Two call sites, fixed identically:

- foundryup/foundryup — the sfoundryup ssolc step, executed by every consumer of setup-sfoundry-style installs (this also removes the script's only jq use, so the jq prerequisite is dropped);
- .github/workflows/seismic.yml — an inline copy of the same lookup in this repo's own test job.