### PR TITLE
fix(anvil): encrypt signed-read revert output in eth_estimateGas

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3310,9 +3310,17 @@ impl EthApi {
         let mut call_to_estimate = seismic_request.clone();
         call_to_estimate.gas = Some(highest_gas_limit as u64);
 
-        // execute the call without writing to db
-        let ethres =
-            self.backend.call_with_state(&state, call_to_estimate, fees.clone(), block_env.clone());
+        // Execute the call without writing to db. Route through the seismic-aware
+        // wrapper (like `eth_call`) so a seismic request's output, including revert
+        // output (which can embed private state just like a successful return value),
+        // is encrypted under the caller's key before it can reach the error path.
+        // Non-seismic requests pass through unencrypted.
+        let ethres = self.backend.seismic_call_with_state(
+            &state,
+            call_to_estimate,
+            fees.clone(),
+            block_env.clone(),
+        );
 
         let gas_used = match ethres.try_into()? {
             GasEstimationCallResult::Success(gas) => Ok(gas),
@@ -3344,7 +3352,9 @@ impl EthApi {
         while (highest_gas_limit - lowest_gas_limit) > 1 {
             seismic_request.set_gas_limit(mid_gas_limit as u64);
             let request = seismic_request.clone().inner;
-            let ethres = self.backend.call_with_state(
+            // Seismic-aware for the same reason as the initial estimate call above:
+            // revert output must not leave the node in cleartext.
+            let ethres = self.backend.seismic_call_with_state(
                 &state,
                 WithOtherFields::new(request.clone()),
                 fees.clone(),

--- a/crates/anvil/tests/it/revert.rs
+++ b/crates/anvil/tests/it/revert.rs
@@ -83,8 +83,14 @@ async fn test_solc_revert_example() {
     let seismic_contract = VendingMachine::new(*contract.address(), &seismic_provider);
     let err = seismic_contract.buy(U256::from(100)).seismic().call().await.unwrap_err();
 
+    // The revert surfaces during signed gas estimation in the fill pipeline. Signed-read
+    // revert output is encrypted under the caller's key (it can embed private state just
+    // like a successful return value), so the plaintext reason must NOT appear on the
+    // wire; only a generic revert error does. Recovering the reason requires client-side
+    // decryption of the error data, which seismic-alloy does not implement yet.
     let s = err.to_string();
-    assert!(s.contains("Not enough Ether provided."), "{s:?}");
+    assert!(s.contains("execution reverted"), "{s:?}");
+    assert!(!s.contains("Not enough Ether provided."), "revert reason leaked in cleartext: {s:?}");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/1871>


### PR DESCRIPTION
Make `eth_estimateGas` consistent with `eth_call` and with seismic-reth's signed-read semantics.

 Changes:
 - Route both execution sites in `do_estimate_gas_with_state` (the initial gas-probe call and the binary-search calls) through `seismic_call_with_state`, which encrypts all output (including revert bytes) under the caller's key. Non-seismic requests are
   unaffected.
 - Update `test_solc_revert_example` to the new contract: the wire error is a generic execution reverted and must not contain the plaintext reason. Recovering the reason now requires client-side decryption of the error data, which seismic-alloy does not implement yet.