### PR TITLE
chore(deps): bump seismic-crypto and take the well-known key rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.25"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd208e8a87fbc2ca1a3822dd1ea03b0a7a4a841e6fa70db2c236dd30ae2e7018"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.3.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48562f9b4c4e1514cab54af16feaffc18194a38216bbd0c23004ec4667ad696b"
+checksum = "31b67c5a702121e618217f7a86f314918acb2622276d0273490e2d4534490bc0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -1060,7 +1060,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3364,33 +3364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version 0.4.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,7 +3669,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3961,7 +3934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4098,12 +4071,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "figment"
@@ -5277,7 +5244,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -5317,16 +5284,6 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom_or_panic"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
-dependencies = [
- "rand 0.8.5",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5539,6 +5496,12 @@ checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hidapi-rusb"
@@ -6167,7 +6130,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6221,7 +6184,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6803,18 +6766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "mesc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7065,7 +7016,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7310,7 +7261,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "revm",
@@ -8475,7 +8426,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8493,7 +8444,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -8504,7 +8455,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -8520,7 +8471,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8535,7 +8486,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -8548,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "either",
@@ -8560,7 +8511,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -8578,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "either",
@@ -8620,7 +8571,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8632,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8656,7 +8607,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -8667,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -8891,7 +8842,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9097,27 +9048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schnorrkel"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9fcb6c2e176e86ec703e22560d99d65a5ee9056ae45a08e13e84ebf796296f"
-dependencies = [
- "aead",
- "arrayref",
- "arrayvec",
- "cfg-if",
- "curve25519-dalek",
- "getrandom_or_panic",
- "merlin",
- "rand_core 0.6.4",
- "serde",
- "serde_bytes",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9249,14 +9179,17 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
+ "alloy-eip2930",
+ "alloy-eip7702",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "alloy-tx-macros",
  "anyhow",
  "derive_more 1.0.0",
  "jsonrpsee",
@@ -9272,10 +9205,11 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
@@ -9300,8 +9234,9 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
+ "alloy-chains",
  "alloy-contract",
  "alloy-network",
  "alloy-primitives",
@@ -9321,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9339,13 +9274,13 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=7dc159d50f7142466e0ac5c73e15d524d996b5b2#7dc159d50f7142466e0ac5c73e15d524d996b5b2"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "hex-literal",
  "hkdf",
  "rand 0.9.2",
- "schnorrkel",
  "secp256k1 0.30.0",
  "serde",
  "sha2",
@@ -9354,7 +9289,7 @@ dependencies = [
 [[package]]
 name = "seismic-prelude"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -9379,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -9440,16 +9375,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -9899,7 +9824,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.0",
 ]
@@ -10240,7 +10165,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -10347,7 +10272,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10367,7 +10292,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11669,7 +11594,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -379,7 +379,7 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 # If our dependencies depend on these things,
 # then this will override whatever versions they point to
 # and instead use our local version
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "7dc159d50f7142466e0ac5c73e15d524d996b5b2" }
 
 # seismic-alloy-core
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -394,21 +394,21 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # seismic-revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "025bdf5924af5aa966c5b349f1f11a6d3e547fa4" }
 
 # seismic-alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
-seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
+seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
 
 # alloy-evm
 alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -673,7 +673,7 @@ impl PendingTransaction {
                     authorization_list,
                 } = &tx.tx();
 
-                let tx_io_sk = seismic_crypto::get_unsecure_sample_secp256k1_sk();
+                let tx_io_sk = seismic_crypto::well_known_tx_io_keypair().secret_key();
                 let tx_metadata = tx.tx().tx_metadata(caller);
                 OpTransaction::new(TxEnv {
                     caller,
@@ -1744,7 +1744,7 @@ mod tests {
         b256,
         hex::{self, FromHex},
     };
-    use seismic_crypto::get_unsecure_sample_secp256k1_pk;
+    use seismic_crypto::well_known_tx_io_keypair;
     use std::str::FromStr;
 
     // <https://github.com/foundry-rs/foundry/issues/10852>
@@ -2001,7 +2001,7 @@ mod tests {
             to: Address::from_str("d3e8763675e4c425df46cc3b5c0f6cbdac396046").unwrap().into(),
             value: U256::from(1000000000000000u64),
             seismic_elements: TxSeismicElements {
-                encryption_pubkey: get_unsecure_sample_secp256k1_pk(),
+                encryption_pubkey: well_known_tx_io_keypair().public_key(),
                 encryption_nonce: U96::from_str("0x46a2b6020bba77fcb1e676a6").unwrap(),
                 message_version: 0,
                 recent_block_hash: FixedBytes::<32>::from_hex(
@@ -2055,7 +2055,7 @@ mod tests {
             value: U256::ZERO,
             input: Bytes::new(),
             seismic_elements: TxSeismicElements {
-                encryption_pubkey: get_unsecure_sample_secp256k1_pk(),
+                encryption_pubkey: well_known_tx_io_keypair().public_key(),
                 encryption_nonce: U96::ZERO,
                 message_version: 0,
                 recent_block_hash: B256::ZERO,

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -181,9 +181,8 @@ impl EthApi {
         trace!(target: "rpc::api", "executing eth request");
         let response = match request.clone() {
             EthRequest::SeismicGetTeePublicKey(()) => {
-                // Use the unsecure sample public key for mock/testing
                 let result: Result<seismic_crypto::secp256k1::PublicKey> =
-                    Ok(seismic_crypto::get_unsecure_sample_secp256k1_pk());
+                    Ok(seismic_crypto::well_known_tx_io_keypair().public_key());
                 result.to_rpc_result()
             }
             EthRequest::Web3ClientVersion(()) => self.client_version().to_rpc_result(),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -121,7 +121,7 @@ use revm::{
     primitives::{FlaggedStorage, KECCAK_EMPTY, hardfork::SpecId as RevmSpecId},
     state::AccountInfo,
 };
-use seismic_crypto::get_unsecure_sample_secp256k1_sk;
+use seismic_crypto::well_known_tx_io_keypair;
 use std::{
     collections::BTreeMap,
     fmt::Debug,
@@ -1681,7 +1681,7 @@ impl Backend {
     fn check_calldata_decryption(
         seismic_request: &TransactionRequest,
     ) -> Result<(), BlockchainError> {
-        match seismic_request.to_transaction_request(&get_unsecure_sample_secp256k1_sk()) {
+        match seismic_request.to_transaction_request(&well_known_tx_io_keypair().secret_key()) {
             // check if we can decrypt calldata before building call env
             // because it will panic inside there
             Ok(_) => Ok(()),
@@ -1757,7 +1757,7 @@ impl Backend {
         let caller = from.unwrap_or_default();
         let to = to.as_ref().and_then(TxKind::to);
         let blob_hashes = blob_versioned_hashes.unwrap_or_default();
-        let tx_io_sk = seismic_crypto::get_unsecure_sample_secp256k1_sk();
+        let tx_io_sk = seismic_crypto::well_known_tx_io_keypair().secret_key();
 
         let kind = match to {
             Some(addr) => TxKind::Call(*addr),
@@ -2155,7 +2155,7 @@ impl Backend {
         block_env: BlockEnv,
     ) -> Result<(InstructionResult, Option<Output>, u128, State), BlockchainError> {
         let tx_metadata = Self::validate_seismic_call_tx_metadata(&request)?;
-        let tx_io_sk = seismic_crypto::get_unsecure_sample_secp256k1_sk();
+        let tx_io_sk = seismic_crypto::well_known_tx_io_keypair().secret_key();
         if let Some(metadata) = &tx_metadata {
             let encrypted_input = request.inner.input.clone().input.unwrap_or(Bytes::new()).clone();
             if let Err(e) = metadata.decrypt_request(&tx_io_sk, &encrypted_input) {
@@ -3805,7 +3805,7 @@ impl TransactionValidator for Backend {
             if tx_metadata.seismic_elements.signed_read {
                 return Err(InvalidTransactionError::SignedReadMismatch);
             }
-            let tx_io_sk = seismic_crypto::get_unsecure_sample_secp256k1_sk();
+            let tx_io_sk = seismic_crypto::well_known_tx_io_keypair().secret_key();
             let _decrypted_data = inner
                 .seismic_elements
                 .decrypt_request(&tx_io_sk, &inner.input, &tx_metadata)

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -179,7 +179,7 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
                     | NamedChain::AcalaMandalaTestnet
                     | NamedChain::AcalaTestnet
                     | NamedChain::Etherlink
-                    | NamedChain::EtherlinkTestnet
+                    | NamedChain::EtherlinkShadownet
                     | NamedChain::Karura
                     | NamedChain::KaruraTestnet
                     | NamedChain::Mantle


### PR DESCRIPTION
Part of SEI-172

seismic-crypto renamed its well-known network key getters for what they are (SeismicSystems/enclave#262): these are the keys every network without a root key actually runs, not test fixtures. sanvil serves the well-known tx-io public key from seismic_getTeePublicKey and decrypts calldata with the secret half, so every call site here takes the rename. The key values are unchanged.

The seismic-revm and seismic-alloy pins move to the revs carrying the same rename (SeismicSystems/seismic-revm#239,
SeismicSystems/seismic-alloy#113). The alloy-evm pin stays where it is: nothing here builds a PurposeKeys, and the newer revs rename alloy_evm::overrides::StateOverrideError, which anvil's error module imports.

seismic-alloy exact-pins alloy-chains at =0.2.34 so the constraint reaches its consumers, which moves this lock from 0.2.25 to 0.2.34. alloy-chains replaced EtherlinkTestnet (128123) with EtherlinkShadownet (127823) in that range, so the different-gas-calc chain list names the Etherlink test network that crate now knows.
